### PR TITLE
fix!: Switch usage of u64 in numeric generics to u32

### DIFF
--- a/src/bignum_test.nr
+++ b/src/bignum_test.nr
@@ -12,7 +12,7 @@ use crate::BigNumTrait;
 
 struct Test2048Params{}
 impl RuntimeBigNumParamsTrait<18> for Test2048Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2048
     }
 }
@@ -80,7 +80,7 @@ impl BigNumParamsTrait<18> for Test2048Params {
     ];
     BigNumInstance::new(modulus, redc_param)
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2048
     }
 }
@@ -88,7 +88,7 @@ impl BigNumParamsTrait<18> for Test2048Params {
 type Fq = BigNum<3, BNParams>;
 type Fqq = BigNum<18, Test2048Params>;
 
-fn test_eq<BigNum, let N: u64>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
+fn test_eq<BigNum, let N: u32>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
     let a = BigNum::__derive_from_seed([1, 2, 3, 4]);
     let b = BigNum::__derive_from_seed([1, 2, 3, 4]);
     let c = BigNum::__derive_from_seed([2, 2, 3, 4]);
@@ -103,7 +103,7 @@ fn test_eq<BigNum, let N: u64>(_: BigNum, __: [Field; N]) where BigNum: BigNumTr
     assert(c.eq(a) == false);
 }
 
-// fn test_eq<let N: u64, Params>(_: BigNum<N, Params>) where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N> {
+// fn test_eq<let N: u32, Params>(_: BigNum<N, Params>) where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N> {
 //     let a = BigNum::__derive_from_seed([1, 2, 3, 4]);
 //     let b = BigNum::__derive_from_seed([1, 2, 3, 4]);
 //     let c = BigNum::__derive_from_seed([2, 2, 3, 4]);
@@ -188,7 +188,7 @@ fn assert_is_not_equal_fail<BigNum>(_: BigNum) where BigNum: BigNumTrait {
     a.assert_is_not_equal(b);
 }
 
-fn assert_is_not_equal_overloaded_lhs_fail<BigNum, let N: u64>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
+fn assert_is_not_equal_overloaded_lhs_fail<BigNum, let N: u32>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
     let a = BigNum::__derive_from_seed([1, 2, 3, 4]);
     let b = BigNum::__derive_from_seed([1, 2, 3, 4]);
 
@@ -200,7 +200,7 @@ fn assert_is_not_equal_overloaded_lhs_fail<BigNum, let N: u64>(_: BigNum, __: [F
     a_plus_modulus.assert_is_not_equal(b);
 }
 
-fn assert_is_not_equal_overloaded_rhs_fail<BigNum, let N: u64>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
+fn assert_is_not_equal_overloaded_rhs_fail<BigNum, let N: u32>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
     let a = BigNum::__derive_from_seed([1, 2, 3, 4]);
     let b = BigNum::__derive_from_seed([1, 2, 3, 4]);
 
@@ -212,7 +212,7 @@ fn assert_is_not_equal_overloaded_rhs_fail<BigNum, let N: u64>(_: BigNum, __: [F
     a.assert_is_not_equal(b_plus_modulus);
 }
 
-fn assert_is_not_equal_overloaded_fail<BigNum, let N: u64>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
+fn assert_is_not_equal_overloaded_fail<BigNum, let N: u32>(_: BigNum, __: [Field; N]) where BigNum: BigNumTrait {
     let a = BigNum::__derive_from_seed([1, 2, 3, 4]);
     let b = BigNum::__derive_from_seed([1, 2, 3, 4]);
 

--- a/src/fields.nr
+++ b/src/fields.nr
@@ -41,31 +41,31 @@ use crate::fields::bn254Fq::BNParams;
  **/
 struct Params512 {}
 impl RuntimeBigNumParamsTrait<5> for Params512 {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         512
     }
 }
 struct Params768 {}
 impl RuntimeBigNumParamsTrait<7> for Params768 {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         768
     }
 }
 struct Params1024 {}
 impl RuntimeBigNumParamsTrait<9> for Params1024 {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         1024
     }
 }
 struct Params2048 {}
 impl RuntimeBigNumParamsTrait<18> for Params2048 {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2048
     }
 }
 struct Params4096 {}
 impl RuntimeBigNumParamsTrait<35> for Params4096 {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         4096
     }
 }

--- a/src/fields/U1024.nr
+++ b/src/fields/U1024.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U1024Params {}
 impl RuntimeBigNumParamsTrait<18> for U1024Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2049
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<18> for U1024Params {
     fn get_instance() -> BigNumInstance<18, Self> {
         U1024_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2049
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U2048.nr
+++ b/src/fields/U2048.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U2048Params {}
 impl RuntimeBigNumParamsTrait<18> for U2048Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2049
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<18> for U2048Params {
     fn get_instance() -> BigNumInstance<18, Self> {
         U2048_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2049
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U256.nr
+++ b/src/fields/U256.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U256Params {}
 impl RuntimeBigNumParamsTrait<3> for U256Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         257
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<3> for U256Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         U256_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         257
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U384.nr
+++ b/src/fields/U384.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U384_Params {}
 impl RuntimeBigNumParamsTrait<4> for U384_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         385
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<4> for U384_Params {
     fn get_instance() -> BigNumInstance<4, Self> {
         U384_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         385
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U4096.nr
+++ b/src/fields/U4096.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U4096Params {}
 impl RuntimeBigNumParamsTrait<35> for U4096Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         4097
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<35> for U4096Params {
     fn get_instance() -> BigNumInstance<35, Self> {
         U4096_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         4097
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U512.nr
+++ b/src/fields/U512.nr
@@ -10,7 +10,7 @@ use crate::utils::arrayX::ArrayX;
 // b * c + (rem < modulus) = a
 struct U512Params {}
 impl RuntimeBigNumParamsTrait<5> for U512Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         513
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -19,7 +19,7 @@ impl BigNumParamsTrait<5> for U512Params {
     fn get_instance() -> BigNumInstance<5, Self> {
         U512_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         513
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U768.nr
+++ b/src/fields/U768.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U768Params {}
 impl RuntimeBigNumParamsTrait<13> for U768Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         1537
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<13> for U768Params {
     fn get_instance() -> BigNumInstance<13, Self> {
         U768_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         1537
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/U8192.nr
+++ b/src/fields/U8192.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct U8192Params {}
 impl RuntimeBigNumParamsTrait<69> for U8192Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         8193
     }
     fn has_multiplicative_inverse() -> bool { false }
@@ -16,7 +16,7 @@ impl BigNumParamsTrait<69> for U8192Params {
     fn get_instance() -> BigNumInstance<69, Self> {
         U8192_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         8193
     }
     fn has_multiplicative_inverse() -> bool { false }

--- a/src/fields/bls12_377Fq.nr
+++ b/src/fields/bls12_377Fq.nr
@@ -25,7 +25,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct BLS12_377_Fq_Params {}
 impl RuntimeBigNumParamsTrait<4> for BLS12_377_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         377
     }
 }
@@ -33,7 +33,7 @@ impl BigNumParamsTrait<4> for BLS12_377_Fq_Params {
     fn get_instance() -> BigNumInstance<4, Self> {
         BLS12_377_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         377
     }
 }

--- a/src/fields/bls12_377Fr.nr
+++ b/src/fields/bls12_377Fr.nr
@@ -25,7 +25,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct BLS12_377_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for BLS12_377_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         253
     }
 }
@@ -33,7 +33,7 @@ impl BigNumParamsTrait<3> for BLS12_377_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         BLS12_377_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         253
     }
 }

--- a/src/fields/bls12_381Fq.nr
+++ b/src/fields/bls12_381Fq.nr
@@ -23,7 +23,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct BLS12_381_Fq_Params {}
 impl RuntimeBigNumParamsTrait<4> for BLS12_381_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         381
     }
 }
@@ -31,7 +31,7 @@ impl BigNumParamsTrait<4> for BLS12_381_Fq_Params {
     fn get_instance() -> BigNumInstance<4, Self> {
         BLS12_381_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         381
     }
 }

--- a/src/fields/bls12_381Fr.nr
+++ b/src/fields/bls12_381Fr.nr
@@ -23,7 +23,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct BLS12_381_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for BLS12_381_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }
@@ -31,7 +31,7 @@ impl BigNumParamsTrait<3> for BLS12_381_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         BLS12_381_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }

--- a/src/fields/bn254Fq.nr
+++ b/src/fields/bn254Fq.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct BNParams {}
 impl RuntimeBigNumParamsTrait<3> for BNParams {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         254
     }
 }
@@ -32,7 +32,7 @@ impl BigNumParamsTrait<3> for BNParams {
     fn get_instance() -> BigNumInstance<3, Self> {
         BN254INSTANCE
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         254
     }
 }

--- a/src/fields/ed25519Fq.nr
+++ b/src/fields/ed25519Fq.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct ED25519_Fq_Params {}
 impl RuntimeBigNumParamsTrait<3> for ED25519_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<3> for ED25519_Fq_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         ED25519_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }

--- a/src/fields/ed25519Fr.nr
+++ b/src/fields/ed25519Fr.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct ED25519_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for ED25519_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         253
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<3> for ED25519_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         ED25519_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         253
     }
 }

--- a/src/fields/mnt4_753Fq.nr
+++ b/src/fields/mnt4_753Fq.nr
@@ -28,7 +28,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct MNT4_753_Fq_Params {}
 impl RuntimeBigNumParamsTrait<7> for MNT4_753_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }
@@ -36,7 +36,7 @@ impl BigNumParamsTrait<7> for MNT4_753_Fq_Params {
     fn get_instance() -> BigNumInstance<7, Self> {
         MNT4_753_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }

--- a/src/fields/mnt4_753Fr.nr
+++ b/src/fields/mnt4_753Fr.nr
@@ -28,7 +28,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct MNT4_753_Fr_Params {}
 impl RuntimeBigNumParamsTrait<7> for MNT4_753_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }
@@ -36,7 +36,7 @@ impl BigNumParamsTrait<7> for MNT4_753_Fr_Params {
     fn get_instance() -> BigNumInstance<7, Self> {
         MNT4_753_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }

--- a/src/fields/mnt6_753Fq.nr
+++ b/src/fields/mnt6_753Fq.nr
@@ -28,7 +28,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct MNT6_753_Fq_Params {}
 impl RuntimeBigNumParamsTrait<7> for MNT6_753_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }
@@ -36,7 +36,7 @@ impl BigNumParamsTrait<7> for MNT6_753_Fq_Params {
     fn get_instance() -> BigNumInstance<7, Self> {
         MNT6_753_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }

--- a/src/fields/mnt6_753Fr.nr
+++ b/src/fields/mnt6_753Fr.nr
@@ -28,7 +28,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct MNT6_753_Fr_Params {}
 impl RuntimeBigNumParamsTrait<7> for MNT6_753_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }
@@ -36,7 +36,7 @@ impl BigNumParamsTrait<7> for MNT6_753_Fr_Params {
     fn get_instance() -> BigNumInstance<7, Self> {
         MNT6_753_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         753
     }
 }

--- a/src/fields/pallasFq.nr
+++ b/src/fields/pallasFq.nr
@@ -22,7 +22,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Pallas_Fq_Params {}
 impl RuntimeBigNumParamsTrait<3> for Pallas_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }
@@ -30,7 +30,7 @@ impl BigNumParamsTrait<3> for Pallas_Fq_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Pallas_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }

--- a/src/fields/pallasFr.nr
+++ b/src/fields/pallasFr.nr
@@ -22,7 +22,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Pallas_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for Pallas_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }
@@ -30,7 +30,7 @@ impl BigNumParamsTrait<3> for Pallas_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Pallas_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }

--- a/src/fields/secp256k1Fq.nr
+++ b/src/fields/secp256k1Fq.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Secp256k1_Fq_Params {}
 impl RuntimeBigNumParamsTrait<3> for Secp256k1_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<3> for Secp256k1_Fq_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Secp256k1_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }

--- a/src/fields/secp256k1Fr.nr
+++ b/src/fields/secp256k1Fr.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Secp256k1_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for Secp256k1_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<3> for Secp256k1_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Secp256k1_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }

--- a/src/fields/secp256r1Fq.nr
+++ b/src/fields/secp256r1Fq.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Secp256r1_Fq_Params {}
 impl RuntimeBigNumParamsTrait<3> for Secp256r1_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<3> for Secp256r1_Fq_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Secp256r1_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }

--- a/src/fields/secp256r1Fr.nr
+++ b/src/fields/secp256r1Fr.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Secp256r1_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for Secp256r1_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<3> for Secp256r1_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Secp256r1_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         256
     }
 }

--- a/src/fields/secp384r1Fq.nr
+++ b/src/fields/secp384r1Fq.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Secp384r1_Fq_Params {}
 impl RuntimeBigNumParamsTrait<4> for Secp384r1_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         384
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<4> for Secp384r1_Fq_Params {
     fn get_instance() -> BigNumInstance<4, Self> {
         Secp384r1_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         384
     }
 }

--- a/src/fields/secp384r1Fr.nr
+++ b/src/fields/secp384r1Fr.nr
@@ -7,7 +7,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Secp384r1_Fr_Params {}
 impl RuntimeBigNumParamsTrait<4> for Secp384r1_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         384
     }
 }
@@ -15,7 +15,7 @@ impl BigNumParamsTrait<4> for Secp384r1_Fr_Params {
     fn get_instance() -> BigNumInstance<4, Self> {
         Secp384r1_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         384
     }
 }

--- a/src/fields/vestaFq.nr
+++ b/src/fields/vestaFq.nr
@@ -23,7 +23,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Vesta_Fq_Params {}
 impl RuntimeBigNumParamsTrait<3> for Vesta_Fq_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }
@@ -31,7 +31,7 @@ impl BigNumParamsTrait<3> for Vesta_Fq_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Vesta_Fq_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }

--- a/src/fields/vestaFr.nr
+++ b/src/fields/vestaFr.nr
@@ -23,7 +23,7 @@ use crate::utils::arrayX::ArrayX;
 
 struct Vesta_Fr_Params {}
 impl RuntimeBigNumParamsTrait<3> for Vesta_Fr_Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }
@@ -31,7 +31,7 @@ impl BigNumParamsTrait<3> for Vesta_Fr_Params {
     fn get_instance() -> BigNumInstance<3, Self> {
         Vesta_Fr_Instance
     }
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         255
     }
 }

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -12,7 +12,7 @@ use crate::runtime_bignum::BigNumInstance as RuntimeBigNumInstance;
 use crate::runtime_bignum::BigNumInstanceTrait as RuntimeBigNumInstanceTrait;
 use crate::runtime_bignum::BigNumParamsTrait as RuntimeBigNumParamsTrait;
 use crate::runtime_bignum::BigNumTrait as RuntimeBigNumTrait;
-struct BigNum<let N: u64, Params> {
+struct BigNum<let N: u32, Params> {
     limbs: [Field; N]
 }
 
@@ -21,15 +21,15 @@ struct BigNum<let N: u64, Params> {
  * @description The "field" does not need to be prime, any value *should* work (TODO: test!)
 **/
 // 
-// trait BigNumParamsTrait<let N: u64, Params> where Params: RuntimeBigNumParamsTrait<N>, RuntimeBigNumInstance<N, Params>: RuntimeBigNumInstanceTrait<BigNum<N, Params>> {
-trait BigNumParamsTrait<let N: u64> where Self: RuntimeBigNumParamsTrait<N> {
+// trait BigNumParamsTrait<let N: u32, Params> where Params: RuntimeBigNumParamsTrait<N>, RuntimeBigNumInstance<N, Params>: RuntimeBigNumInstanceTrait<BigNum<N, Params>> {
+trait BigNumParamsTrait<let N: u32> where Self: RuntimeBigNumParamsTrait<N> {
 
     fn get_instance() -> RuntimeBigNumInstance<N, Self> where Self: RuntimeBigNumParamsTrait<N>;// <N, Params>;
 
     /**
      * @brief modulus_bits = log2(modulus) rounded up
      **/
-    fn modulus_bits() -> u64;
+    fn modulus_bits() -> u32;
 
     fn has_multiplicative_inverse() -> bool { true }
 }
@@ -41,9 +41,9 @@ trait BigNumTrait where BigNumTrait: std::ops::Add + std::ops::Sub + std::ops::M
     fn new() -> Self { RuntimeBigNumTrait::new() }
     fn one() -> Self { RuntimeBigNumTrait::one() }
     fn modulus() -> Self;
-    fn modulus_bits(self) -> u64;
-    fn num_limbs(self) -> u64;
-    fn __derive_from_seed<let SeedBytes: u64>(seed: [u8; SeedBytes]) -> Self;
+    fn modulus_bits(self) -> u32;
+    fn num_limbs(self) -> u32;
+    fn __derive_from_seed<let SeedBytes: u32>(seed: [u8; SeedBytes]) -> Self;
     fn __pow(self, exponent: Self) -> Self;
     fn __neg(self) -> Self;
     fn __add(self, other: Self) -> Self;
@@ -52,12 +52,12 @@ trait BigNumTrait where BigNumTrait: std::ops::Add + std::ops::Sub + std::ops::M
     fn __div(self, other: Self) -> Self;
     fn __udiv_mod(self, divisor: Self) -> (Self, Self);
     fn __invmod(self) -> Self;
-    fn __batch_invert<let M: u64>(to_invert: [Self; M]) -> [Self; M];
+    fn __batch_invert<let M: u32>(to_invert: [Self; M]) -> [Self; M];
     fn __batch_invert_slice(x: [Self]) -> [Self];
     fn __is_zero(self) -> bool { RuntimeBigNumTrait::__is_zero(self) }
     fn __eq(self, other: Self) -> bool { RuntimeBigNumTrait::__eq(self, other) }
-    fn __compute_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(lhs: [[Self; LHS_N]; NUM_PRODUCTS], lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS], rhs: [[Self; RHS_N]; NUM_PRODUCTS], rhs_flags: [[bool; RHS_N]; NUM_PRODUCTS], add: [Self; ADD_N], add_flags: [bool; ADD_N]) -> (Self, Self);
-    fn evaluate_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(lhs: [[Self; LHS_N]; NUM_PRODUCTS], lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS], rhs: [[Self; RHS_N]; NUM_PRODUCTS], rhs_flags: [[bool; RHS_N]; NUM_PRODUCTS], add: [Self; ADD_N], add_flags: [bool; ADD_N]);
+    fn __compute_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(lhs: [[Self; LHS_N]; NUM_PRODUCTS], lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS], rhs: [[Self; RHS_N]; NUM_PRODUCTS], rhs_flags: [[bool; RHS_N]; NUM_PRODUCTS], add: [Self; ADD_N], add_flags: [bool; ADD_N]) -> (Self, Self);
+    fn evaluate_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(lhs: [[Self; LHS_N]; NUM_PRODUCTS], lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS], rhs: [[Self; RHS_N]; NUM_PRODUCTS], rhs_flags: [[bool; RHS_N]; NUM_PRODUCTS], add: [Self; ADD_N], add_flags: [bool; ADD_N]);
     fn validate_in_range(self){ RuntimeBigNumTrait::validate_in_range(self) }
     fn validate_in_field(self);
     fn assert_is_not_equal(self, other: Self);
@@ -72,23 +72,23 @@ trait BigNumTrait where BigNumTrait: std::ops::Add + std::ops::Sub + std::ops::M
     fn eq(self, other: Self) -> bool { self == other }
     fn get(self) -> [Field] { RuntimeBigNumTrait::get(self) }
     fn get_limb(self, idx: u64) -> Field  { RuntimeBigNumTrait::get_limb(self, idx) }
-    fn set_limb(&mut self, idx: u64, value: Field)  { RuntimeBigNumTrait::set_limb(self, idx, value) }
+    fn set_limb(&mut self, idx: u32, value: Field)  { RuntimeBigNumTrait::set_limb(self, idx, value) }
     fn conditional_select(lhs: Self, rhs: Self, predicate: bool) -> Self { RuntimeBigNumTrait::conditional_select(lhs, rhs, predicate) }
-    fn to_le_bytes<let X: u64>(self) -> [u8; X] { RuntimeBigNumTrait::to_le_bytes(self) }
+    fn to_le_bytes<let X: u32>(self) -> [u8; X] { RuntimeBigNumTrait::to_le_bytes(self) }
 }
 
-impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N> {
+impl<let N: u32, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N> {
 
     
     // Weird compiler issue where if we do not pass `Self` as a parameter to these methods,
     // then a generic struct that conforms to BigNumTrait cannot access these methods?
     // the Params: BigNumParamsTrait<N> needs to be satisfied, but the BigNumTrait has no knowledge of BigNumParamsTrait?
     // but...passing in a Self parameter seems to fix. really weird
-    fn modulus_bits(_: Self) -> u64 {
-        let r: u64 = Params::modulus_bits();
+    fn modulus_bits(_: Self) -> u32 {
+        let r: u32 = Params::modulus_bits();
         r
     }
-    fn num_limbs(_: Self) -> u64 { N }
+    fn num_limbs(_: Self) -> u32 { N }
 
     fn modulus() -> Self {
         Params::get_instance().modulus()
@@ -115,7 +115,7 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
     // ### NOTE: these functions call unconstrained internal implementations because trait impl modifiers are not supported 
     // ####################################################################################################################
     // ####################################################################################################################
-    fn __derive_from_seed<let SeedBytes: u64>(seed: [u8; SeedBytes]) -> Self {
+    fn __derive_from_seed<let SeedBytes: u32>(seed: [u8; SeedBytes]) -> Self {
         Params::get_instance().__derive_from_seed(seed)
     }
 
@@ -139,7 +139,7 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
         Params::get_instance().__div(self, rhs)
     }
 
-    fn __batch_invert<let M: u64>(x: [Self; M]) -> [Self; M] {
+    fn __batch_invert<let M: u32>(x: [Self; M]) -> [Self; M] {
         assert(Params::has_multiplicative_inverse());
         Params::get_instance().__batch_invert(x)
     }
@@ -158,7 +158,7 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
         Params::get_instance().__pow(self, exponent)
     }
 
-    fn __compute_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    fn __compute_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         lhs_terms: [[Self; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
         rhs_terms: [[Self; RHS_N]; NUM_PRODUCTS],
@@ -219,7 +219,7 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
      * @param linear_terms an array of BigNum
      * @param linear_flags an array of sign flags
      **/
-    fn evaluate_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    fn evaluate_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         lhs_terms: [[Self; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
         rhs_terms: [[Self; RHS_N]; NUM_PRODUCTS],
@@ -274,10 +274,10 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
     }
 }
 
-impl<let N: u64, Params> BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
+impl<let N: u32, Params> BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
 }
 
-impl<let N: u64, Params> std::ops::Add for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
+impl<let N: u32, Params> std::ops::Add for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
     // Note: this method is expensive! Try to craft quadratic relations and directly evaluate them
     //       via evaluate_quadratic_expression
     fn add(self, other: Self) -> Self {
@@ -285,7 +285,7 @@ impl<let N: u64, Params> std::ops::Add for BigNum<N, Params> where Params: BigNu
     }
 }
 
-impl<let N: u64, Params> std::ops::Sub for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
+impl<let N: u32, Params> std::ops::Sub for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
     // Note: this method is expensive! Try to craft quadratic relations and directly evaluate them
     //       via evaluate_quadratic_expression
     fn sub(self, other: Self) -> Self {
@@ -293,7 +293,7 @@ impl<let N: u64, Params> std::ops::Sub for BigNum<N, Params> where Params: BigNu
     }
 }
 
-impl<let N: u64, Params> std::ops::Mul for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
+impl<let N: u32, Params> std::ops::Mul for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
     // Note: this method is expensive! Try to craft quadratic relations and directly evaluate them
     //       via evaluate_quadratic_expression
     // e.g. performing a sum of multiple multiplications and additions via `evaluate_quadratic_expression`
@@ -303,14 +303,14 @@ impl<let N: u64, Params> std::ops::Mul for BigNum<N, Params> where Params: BigNu
     }
 }
 
-impl<let N: u64, Params> std::ops::Div for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
+impl<let N: u32, Params> std::ops::Div for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
     // Note: this method is expensive! Witness computation is extremely expensive as it requires modular exponentiation
     fn div(self, other: Self) -> Self {
         Params::get_instance().div(self, other)
     }
 }
 
-impl<let N: u64, Params> std::cmp::Eq for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
+impl<let N: u32, Params> std::cmp::Eq for BigNum<N, Params> where Params: BigNumParamsTrait<N> + RuntimeBigNumParamsTrait<N>  {
 
     fn eq(self, other: Self) -> bool {
         let bn: RuntimeBigNumInstance<N, Params> = Params::get_instance();

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -13,11 +13,11 @@ trait BigNumTrait {
     fn new() -> Self;
     fn one() -> Self;
     fn from(limbs: [Field]) -> Self;
-    fn from_byte_be<let NBytes: u64>(x: [u8; NBytes]) -> Self;
-    fn to_le_bytes<let NBytes: u64>(val: Self) -> [u8; NBytes];
+    fn from_byte_be<let NBytes: u32>(x: [u8; NBytes]) -> Self;
+    fn to_le_bytes<let NBytes: u32>(val: Self) -> [u8; NBytes];
     fn get(self) -> [Field];
     fn get_limb(self, idx: u64) -> Field;
-    fn set_limb(&mut self, idx: u64, value: Field);
+    fn set_limb(&mut self, idx: u32, value: Field);
     fn conditional_select(lhs: Self, rhs: Self, predicate: bool) -> Self;
     fn validate_in_range(self);
     fn validate_quotient_in_range(self);
@@ -32,19 +32,19 @@ trait BigNumTrait {
  **/
 trait BigNumInstanceTrait<BN> where BN: BigNumTrait {
     fn modulus(self) -> BN;
-    fn __derive_from_seed<let SeedBytes: u64>(self, seed: [u8; SeedBytes]) -> BN;
+    fn __derive_from_seed<let SeedBytes: u32>(self, seed: [u8; SeedBytes]) -> BN;
     fn eq(self, lhs: BN, rhs: BN) -> bool;
     fn __neg(self, val: BN) -> BN;
     fn __add(self, lhs: BN, rhs: BN) -> BN;
     fn __sub(self, lhs: BN, rhs: BN) -> BN;
     fn __mul(self, lhs: BN, rhs: BN) -> BN;
     fn __div(self, lhs: BN, rhs: BN) -> BN;
-    fn __batch_invert<let M: u64>(self, x: [BN; M]) -> [BN; M];
+    fn __batch_invert<let M: u32>(self, x: [BN; M]) -> [BN; M];
     fn __batch_invert_slice(self, x: [BN]) -> [BN];
     fn __udiv_mod(self, numerator: BN, divisor: BN) -> (BN, BN);
     fn __invmod(self, val: BN) -> BN;
     fn __pow(self, val: BN, exponent: BN) -> BN;
-    fn __compute_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    fn __compute_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         self,
         lhs_terms: [[BN; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -54,7 +54,7 @@ trait BigNumInstanceTrait<BN> where BN: BigNumTrait {
         linear_flags: [bool; ADD_N]
     ) -> (BN, BN);
 
-    fn evaluate_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    fn evaluate_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         self,
         lhs_terms: [[BN; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -82,16 +82,16 @@ trait BigNumInstanceTrait<BN> where BN: BigNumTrait {
  * @brief BigNumParamsTrait defines a "field" with which to parametrise BigNum.
  * @description The "field" does not need to be prime, any value *should* work (TODO: test!)
 **/
-trait BigNumParamsTrait<let N: u64> {
+trait BigNumParamsTrait<let N: u32> {
     /**
      * @brief modulus_bits = log2(modulus) rounded up
      **/
-    fn modulus_bits() -> u64;
+    fn modulus_bits() -> u32;
 
     fn has_multiplicative_inverse() -> bool { true }
 }
 
-struct BigNumInstance<let N: u64, Params> {
+struct BigNumInstance<let N: u32, Params> {
     
     /**
      * @brief modulus: all BigNum operations are evaluated modulo this value
@@ -114,7 +114,7 @@ struct BigNumInstance<let N: u64, Params> {
     redc_param: [Field; N],
 }
 
-impl<let N: u64, Params> BigNum<N, Params> {
+impl<let N: u32, Params> BigNum<N, Params> {
     // some strange circular dependency problem means we need to define `new` as a member of BigNumTrait as well as a definition outside of the trait
     // (delete this method to see. BigNumInstance methods that use BigNum::new() error out, and I can't find a way of declaring BigNum to satisfy BigNumTrait as part of the BigNumInstance definition because BigNumInstance has no contextual knowledge of the BigNum type...)
     fn new() -> Self {
@@ -127,7 +127,7 @@ impl<let N: u64, Params> BigNum<N, Params> {
     }
 }
 
-impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumParamsTrait<N> {
+impl<let N: u32, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumParamsTrait<N> {
 
     fn new() -> Self {
         BigNum::new()
@@ -144,9 +144,9 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
      *               is precisely large enough to cover Params::modulus_bits()
      * @param x: input byte array
      **/
-    fn from_byte_be<let NBytes: u64>(x: [u8; NBytes]) -> BigNum<N, Params> {
-        let num_bits: u64 = NBytes * 8;
-        let modulus_bits: u64 = Params::modulus_bits();
+    fn from_byte_be<let NBytes: u32>(x: [u8; NBytes]) -> BigNum<N, Params> {
+        let num_bits = NBytes * 8;
+        let modulus_bits = Params::modulus_bits();
         assert(num_bits > modulus_bits);
         assert(num_bits - modulus_bits < 8);
         let mut result = BigNum::new();
@@ -183,8 +183,8 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
         result
     }
 
-    fn to_le_bytes<let NBytes: u64>(val: BigNum<N, Params>) -> [u8; NBytes] {
-        let nbytes = (Params::modulus_bits() / 8) + (Params::modulus_bits() % 8 != 0) as u64;
+    fn to_le_bytes<let NBytes: u32>(val: BigNum<N, Params>) -> [u8; NBytes] {
+        let nbytes = (Params::modulus_bits() / 8) + (Params::modulus_bits() % 8 != 0) as u32;
         assert(nbytes <= NBytes);
 
         let mut result: [u8; NBytes] = [0; NBytes];
@@ -208,7 +208,7 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
     fn get_limb(self, idx: u64) -> Field {
         self.limbs[idx]
     }
-    fn set_limb(&mut self, idx: u64, value: Field) {
+    fn set_limb(&mut self, idx: u32, value: Field) {
         self.limbs[idx] = value;
     }
 
@@ -266,7 +266,7 @@ impl<let N: u64, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
     }
 }
 
-impl<let N: u64, Params> BigNum<N, Params> where Params: BigNumParamsTrait<N> {
+impl<let N: u32, Params> BigNum<N, Params> where Params: BigNumParamsTrait<N> {
 
     fn from_array(limbs: [Field; N]) -> BigNum<N, Params> {
         BigNum { limbs }
@@ -285,10 +285,10 @@ impl<let N: u64, Params> BigNum<N, Params> where Params: BigNumParamsTrait<N> {
     }
 }
 
-impl<let N: u64, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInstance<N, Params> where Params: BigNumParamsTrait<N> {
+impl<let N: u32, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInstance<N, Params> where Params: BigNumParamsTrait<N> {
 
     fn modulus(self) -> BigNum<N, Params> { BigNum{ limbs: self.modulus } }
-    fn __derive_from_seed<let SeedBytes: u64>(self, seed: [u8; SeedBytes]) -> BigNum<N, Params> {
+    fn __derive_from_seed<let SeedBytes: u32>(self, seed: [u8; SeedBytes]) -> BigNum<N, Params> {
         self.__derive_from_seed_impl(seed)
     }
     // ####################################################################################################################
@@ -318,7 +318,7 @@ impl<let N: u64, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInsta
         self.__div_impl(lhs, rhs)
     }
 
-    fn __batch_invert<let M: u64>(self, x: [BigNum<N, Params>; M]) -> [BigNum<N, Params>; M] {
+    fn __batch_invert<let M: u32>(self, x: [BigNum<N, Params>; M]) -> [BigNum<N, Params>; M] {
         self.batch_invert_impl(x)
     }
 
@@ -335,7 +335,7 @@ impl<let N: u64, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInsta
         self.__pow_impl(val, exponent)
     }
 
-    fn __compute_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    fn __compute_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
             self,
             lhs_terms: [[BigNum<N, Params>; LHS_N]; NUM_PRODUCTS],
             lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -399,7 +399,7 @@ impl<let N: u64, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInsta
      * @param linear_terms an array of BigNum
      * @param linear_flags an array of sign flags
      **/
-    fn evaluate_quadratic_expression<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    fn evaluate_quadratic_expression<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         self,
         lhs_terms: [[BigNum<N, Params>; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -789,7 +789,7 @@ impl<let N: u64, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInsta
 
 }
 
-impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTrait<N> {
+impl<let N: u32, Params> BigNumInstance<N, Params> where Params: BigNumParamsTrait<N> {
 
     // ####################################################################################################################
     // ####################################################################################################################
@@ -807,13 +807,13 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
         }
     }
 
-    unconstrained fn __derive_from_seed_impl<let SeedBytes: u64>(self, seed: [u8; SeedBytes]) -> BigNum<N, Params> {
+    unconstrained fn __derive_from_seed_impl<let SeedBytes: u32>(self, seed: [u8; SeedBytes]) -> BigNum<N, Params> {
         let mut rolling_seed = seed;
 
         let mut to_reduce: ArrayX<Field, N, 2> = ArrayX { segments: [[0; N], [0; N]] };
 
         let mut double_modulus_bits = Params::modulus_bits() * 2;
-        let mut double_modulus_bytes = (double_modulus_bits) / 8 + (double_modulus_bits % 8 != 0) as u64;
+        let mut double_modulus_bytes = (double_modulus_bits) / 8 + (double_modulus_bits % 8 != 0) as u32;
 
         let mut last_limb_bytes = double_modulus_bytes % 15;
         if (last_limb_bytes == 0) {
@@ -1159,7 +1159,7 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
         self.__pow(val, result)
     }
 
-    unconstrained fn batch_invert_impl<let M: u64>(self, x: [BigNum<N, Params>; M]) -> [BigNum<N, Params>; M] {
+    unconstrained fn batch_invert_impl<let M: u32>(self, x: [BigNum<N, Params>; M]) -> [BigNum<N, Params>; M] {
         // TODO: ugly! Will fail if input slice is empty
         let mut accumulator: BigNum<N, Params> = BigNum::one();
         let mut result: [BigNum<N, Params>; M] = [BigNum::new(); M];
@@ -1225,7 +1225,7 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
     // We know that, for a valid bignum element, the limbs in `x` will be <2^{120}
     // Therefore each of the limbs in `p` (except the most significant) will borrow 2^{120} from the more significant limb.
     // Finally, to ensure we do not underflow in the most significant limb, we use `2p` instead of `p`
-    unconstrained fn __add_linear_expression<let M: u64>(
+    unconstrained fn __add_linear_expression<let M: u32>(
         self,
         x: [BigNum<N, Params>; M],
         flags: [bool; M]
@@ -1257,7 +1257,7 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
      * @brief computes the limb products of a quadratic expression
      * @details see __compute_quadratic_expression_with_borrow_flags for full description
      **/
-    unconstrained fn __compute_quadratic_expression_product<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    unconstrained fn __compute_quadratic_expression_product<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         self,
         lhs_terms: [[BigNum<N, Params>; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -1295,7 +1295,7 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
      * @brief computes the quotient/remainder of a quadratic expression
      * @details see __compute_quadratic_expression_with_borrow_flags for full description
      **/
-    unconstrained fn __compute_quadratic_expression_impl<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    unconstrained fn __compute_quadratic_expression_impl<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         self,
         lhs_terms: [[BigNum<N, Params>; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -1356,7 +1356,7 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
      * @param linear_terms an array of BigNum
      * @param linear_flags an array of sign flags
      **/
-    unconstrained fn __compute_quadratic_expression_with_borrow_flags<let LHS_N: u64, let RHS_N: u64, let NUM_PRODUCTS: u64, let ADD_N: u64>(
+    unconstrained fn __compute_quadratic_expression_with_borrow_flags<let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(
         self,
         lhs_terms: [[BigNum<N, Params>; LHS_N]; NUM_PRODUCTS],
         lhs_flags: [[bool; LHS_N]; NUM_PRODUCTS],
@@ -1469,7 +1469,7 @@ impl<let N: u64, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
     }
 }
 
-fn get_double_modulus<let N: u64>(modulus: [Field; N]) -> [Field; N] {
+fn get_double_modulus<let N: u32>(modulus: [Field; N]) -> [Field; N] {
     let TWO_POW_120: Field = 0x1000000000000000000000000000000;
     let m: U60Repr<N, 2> = U60Repr::from(modulus);
     let mut result: [Field; N] = U60Repr::into(m + m);
@@ -1482,10 +1482,10 @@ fn get_double_modulus<let N: u64>(modulus: [Field; N]) -> [Field; N] {
     result
 }
 
-unconstrained fn __barrett_reduction<let N: u64>(
+unconstrained fn __barrett_reduction<let N: u32>(
     x: ArrayX<Field, N, 2>,
     redc_param: [Field; N],
-    k: u64,
+    k: u32,
     modulus: [Field; N],
     modulus_u60: U60Repr<N, 4>
 ) -> ([Field; N], [Field; N]) {

--- a/src/runtime_bignum_test.nr
+++ b/src/runtime_bignum_test.nr
@@ -7,7 +7,7 @@ use crate::fields::bn254Fq::BNParams as BNParams;
 use crate::fields::bn254Fq::BN254INSTANCE;
 struct Test2048Params {}
 impl BigNumParamsTrait<18> for Test2048Params {
-    fn modulus_bits() -> u64 {
+    fn modulus_bits() -> u32 {
         2048
     }
 }
@@ -61,7 +61,7 @@ type FqInstance = BigNumInstance<3, BNParams>;
 type Fqq = BigNum<18, Test2048Params>;
 type FqqInstance = BigNumInstance<18, Test2048Params>;
 
-fn test_eq<let N: u64, Params>(BNInstance: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn test_eq<let N: u32, Params>(BNInstance: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = BNInstance.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = BNInstance.__derive_from_seed([1, 2, 3, 4]);
     let c: BigNum<N, Params> = BNInstance.__derive_from_seed([2, 2, 3, 4]);
@@ -80,7 +80,7 @@ fn test_eq<let N: u64, Params>(BNInstance: BigNumInstance<N, Params>) where Para
 // 98760
 // 99689
 // 929 gates for a 2048 bit mul
-fn test_mul<let N: u64, Params>(BNInstance: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn test_mul<let N: u32, Params>(BNInstance: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = BNInstance.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = BNInstance.__derive_from_seed([4, 5, 6, 7]);
 
@@ -95,7 +95,7 @@ fn test_mul<let N: u64, Params>(BNInstance: BigNumInstance<N, Params>) where Par
     assert(BNInstance.eq(c, d));
 }
 
-fn test_add<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn test_add<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([4, 5, 6, 7]);
     let one: BigNum<N, Params> = BigNum::one();
@@ -116,7 +116,7 @@ fn test_add<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: Big
     assert(e.limbs[0] == 2);
 }
 
-fn test_div<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn test_div<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([4, 5, 6, 7]);
 
@@ -124,7 +124,7 @@ fn test_div<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: Big
     assert(bn.eq(bn.mul(b, c), a));
 }
 
-fn test_invmod<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn test_invmod<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let u: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     for _ in 0..1 {
         let v = bn.__invmod(u);
@@ -134,21 +134,21 @@ fn test_invmod<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: 
     }
 }
 
-fn assert_is_not_equal<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn assert_is_not_equal<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([4, 5, 6, 7]);
 
     bn.assert_is_not_equal(a, b);
 }
 
-fn assert_is_not_equal_fail<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn assert_is_not_equal_fail<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
 
     bn.assert_is_not_equal(a, b);
 }
 
-fn assert_is_not_equal_overloaded_lhs_fail<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn assert_is_not_equal_overloaded_lhs_fail<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
 
@@ -160,7 +160,7 @@ fn assert_is_not_equal_overloaded_lhs_fail<let N: u64, Params>(bn: BigNumInstanc
     bn.assert_is_not_equal(a_plus_modulus, b);
 }
 
-fn assert_is_not_equal_overloaded_rhs_fail<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn assert_is_not_equal_overloaded_rhs_fail<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
 
@@ -172,7 +172,7 @@ fn assert_is_not_equal_overloaded_rhs_fail<let N: u64, Params>(bn: BigNumInstanc
     bn.assert_is_not_equal(a, b_plus_modulus);
 }
 
-fn assert_is_not_equal_overloaded_fail<let N: u64, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
+fn assert_is_not_equal_overloaded_fail<let N: u32, Params>(bn: BigNumInstance<N, Params>) where Params: BigNumParamsTrait<N> {
     let a: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
     let b: BigNum<N, Params> = bn.__derive_from_seed([1, 2, 3, 4]);
 

--- a/src/utils/arrayX.nr
+++ b/src/utils/arrayX.nr
@@ -8,11 +8,11 @@ use crate::utils::split_bits;
  *       e.g. [Field; N * 2] is not currently possible
  *       This abstraction can be removed once Noir supports arithmetic on generics.
 **/
-struct ArrayX<T, let N: u64, let SizeMultiplier: u64> {
+struct ArrayX<T, let N: u32, let SizeMultiplier: u32> {
     segments: [[T; N]; SizeMultiplier]
 }
 
-impl<T, let N: u64, let SizeMultiplier: u64> std::convert::From<[T; N]> for ArrayX<T, N, SizeMultiplier> where T: std::default::Default { 
+impl<T, let N: u32, let SizeMultiplier: u32> std::convert::From<[T; N]> for ArrayX<T, N, SizeMultiplier> where T: std::default::Default { 
     fn from(input: [T; N]) -> Self {
         assert(N == 1);
         let mut result = ArrayX::new();
@@ -21,13 +21,13 @@ impl<T, let N: u64, let SizeMultiplier: u64> std::convert::From<[T; N]> for Arra
     }
 }
 
-impl<T, let N: u64, let SizeMultiplier: u64> std::convert::From<[[T; N]; SizeMultiplier]> for ArrayX<T, N, SizeMultiplier> where T: std::default::Default { 
+impl<T, let N: u32, let SizeMultiplier: u32> std::convert::From<[[T; N]; SizeMultiplier]> for ArrayX<T, N, SizeMultiplier> where T: std::default::Default { 
     fn from(input: [[T; N]; SizeMultiplier]) -> Self {
         ArrayX{ segments: input }
     }
 }
 
-impl<T, let N: u64, let SizeMultiplier: u64> std::cmp::Eq for ArrayX<T, N, SizeMultiplier> where T: std::cmp::Eq { 
+impl<T, let N: u32, let SizeMultiplier: u32> std::cmp::Eq for ArrayX<T, N, SizeMultiplier> where T: std::cmp::Eq { 
     fn eq(self, other: Self) -> bool {
         let mut result: bool = true;
         for i in 0..SizeMultiplier {
@@ -39,43 +39,43 @@ impl<T, let N: u64, let SizeMultiplier: u64> std::cmp::Eq for ArrayX<T, N, SizeM
     }
 }
 
-impl<T, let N: u64, let SizeMultiplier: u64> ArrayX<T, N, SizeMultiplier> {
+impl<T, let N: u32, let SizeMultiplier: u32> ArrayX<T, N, SizeMultiplier> {
 
     fn new() -> Self where T: std::default::Default {
         ArrayX { segments: [[T::default(); N]; SizeMultiplier] }
     }
 
-    fn mul_assign(&mut self, i: u64, rhs: T) where T: std::ops::Mul {
+    fn mul_assign(&mut self, i: u32, rhs: T) where T: std::ops::Mul {
         let segment = i / N;
         let index = i % N;
         self.segments[segment][index] *= rhs;
     }
 
-    fn add_assign(&mut self, i: u64, rhs: T) where T: std::ops::Add {
+    fn add_assign(&mut self, i: u32, rhs: T) where T: std::ops::Add {
         let segment = i / N;
         let index = i % N;
         self.segments[segment][index] += rhs;
     }
 
-    fn sub_assign(&mut self, i: u64, rhs: T) where T: std::ops::Sub {
+    fn sub_assign(&mut self, i: u32, rhs: T) where T: std::ops::Sub {
         let segment = i / N;
         let index = i % N;
         self.segments[segment][index] -= rhs;
     }
 
-    fn set(&mut self, i: u64, x: T) {
+    fn set(&mut self, i: u32, x: T) {
         let segment = i / N;
         let index = i % N;
         self.segments[segment][index] = x;
     }
 
-    fn get(self, i: u64) -> T {
+    fn get(self, i: u32) -> T {
         let segment = i / N;
         let index = i % N;
         self.segments[segment][index]
     }
 
-    unconstrained fn __normalize_limbs<let NumSegments: u64>(x: ArrayX<Field, N, NumSegments>, range: u64) -> ArrayX<Field, N, NumSegments> {
+    unconstrained fn __normalize_limbs<let NumSegments: u32>(x: ArrayX<Field, N, NumSegments>, range: u32) -> ArrayX<Field, N, NumSegments> {
         let mut normalized: ArrayX<Field, N, NumSegments> = ArrayX::new();
         let mut inp = x;
         // (9 limb mul = 17 product terms)

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -1,8 +1,10 @@
 use crate::utils::u60_representation::U60Repr;
 
-global n1: u64 = 0xffffffffffffffff;
+/// Multiple entires in the `MUL_DE_BRUIJN_BIT` list do not map to a valid output of `v * 0x6c04f118e9966f6b`.
+/// This is a dummy value to fill the gaps in the map.
+global n1: u32 = 0xffffffff;
 
-global MUL_DE_BRUIJN_BIT: [u64; 128] = [
+global MUL_DE_BRUIJN_BIT: [u32; 128] = [
         0,// change to 1 if you want bitSize(0) = 1
         48, n1, n1, 31, n1, 15, 51, n1, 63, 5, n1, n1, n1, 19, n1,
         23, 28, n1, n1, n1, 40, 36, 46, n1, 13, n1, n1, n1, 34, n1, 58,
@@ -13,7 +15,8 @@ global MUL_DE_BRUIJN_BIT: [u64; 128] = [
         41, n1, 25, 37, n1, 47, n1, 30, 14, n1, n1, n1, n1, 22, n1, n1,
         35, 12, n1, n1, n1, 59, 42, n1, n1, 61, 3, 26, 38, 44, n1, 56
     ];
-unconstrained pub fn get_msb64(x: u64) -> u64 {
+    
+unconstrained pub fn get_msb64(x: u64) -> u32 {
     let mut v = x;
     v |= v >> 1;
     v |= v >> 2;
@@ -23,7 +26,5 @@ unconstrained pub fn get_msb64(x: u64) -> u64 {
     v |= v >> 32;
     MUL_DE_BRUIJN_BIT[(std::wrapping_mul(v, 0x6c04f118e9966f6b)) >> 57]
 }
-
-
 
 // 1100

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -15,7 +15,7 @@ global MUL_DE_BRUIJN_BIT: [u32; 128] = [
         41, n1, 25, 37, n1, 47, n1, 30, 14, n1, n1, n1, n1, 22, n1, n1,
         35, 12, n1, n1, n1, 59, 42, n1, n1, 61, 3, 26, 38, 44, n1, 56
     ];
-    
+
 unconstrained pub fn get_msb64(x: u64) -> u32 {
     let mut v = x;
     v |= v >> 1;

--- a/src/utils/u60_representation.nr
+++ b/src/utils/u60_representation.nr
@@ -10,12 +10,12 @@ use crate::utils::msb::get_msb64;
  * It is helpful to use u60 types when evaluating addition operations that can overflow the field modulus,
  * as well as when performing bit shifts.
  */
-struct U60Repr<let N: u64, let NumSegments: u64>
+struct U60Repr<let N: u32, let NumSegments: u32>
 {
     limbs: ArrayX<u64, N, NumSegments>
 }
 
-impl<let N: u64, let NumSegments: u64> std::ops::Add for U60Repr<N, NumSegments> {
+impl<let N: u32, let NumSegments: u32> std::ops::Add for U60Repr<N, NumSegments> {
     fn add(self, b: Self) -> Self {
         let mut result: Self = U60Repr { limbs: ArrayX { segments: [[0; N]; NumSegments] } };
 
@@ -33,7 +33,7 @@ impl<let N: u64, let NumSegments: u64> std::ops::Add for U60Repr<N, NumSegments>
     }
 }
 
-impl<let N: u64, let NumSegments: u64> std::ops::Sub for U60Repr<N, NumSegments> {
+impl<let N: u32, let NumSegments: u32> std::ops::Sub for U60Repr<N, NumSegments> {
     fn sub(self, b: Self) -> Self {
         let mut result: Self = U60Repr { limbs: ArrayX { segments: [[0; N]; NumSegments] } };
 
@@ -52,7 +52,7 @@ impl<let N: u64, let NumSegments: u64> std::ops::Sub for U60Repr<N, NumSegments>
     }
 }
 
-impl<let N: u64, let NumSegments: u64> std::convert::From<[Field; N]> for U60Repr<N, NumSegments> { 
+impl<let N: u32, let NumSegments: u32> std::convert::From<[Field; N]> for U60Repr<N, NumSegments> { 
     fn from(input: [Field; N]) -> Self {
         let mut result: Self = U60Repr { limbs: ArrayX { segments: [[0; N]; NumSegments] } };
         for i in 0..(N) {
@@ -64,7 +64,7 @@ impl<let N: u64, let NumSegments: u64> std::convert::From<[Field; N]> for U60Rep
     }
 }
 
-impl<let N: u64, let NumSegments: u64> std::convert::Into<[Field; N]> for U60Repr<N, NumSegments> {
+impl<let N: u32, let NumSegments: u32> std::convert::Into<[Field; N]> for U60Repr<N, NumSegments> {
     fn into(x: U60Repr<N, NumSegments>) -> [Field; N] {
         let mut result: [Field; N] = [0; N];
         let two_pow_60: Field = 0x1000000000000000;
@@ -75,15 +75,15 @@ impl<let N: u64, let NumSegments: u64> std::convert::Into<[Field; N]> for U60Rep
     }
 }
 
-impl<let N: u64, let NumSegments: u64> std::cmp::Eq for U60Repr<N, NumSegments> { 
+impl<let N: u32, let NumSegments: u32> std::cmp::Eq for U60Repr<N, NumSegments> { 
     fn eq(self, other: Self) -> bool {
         self.limbs == other.limbs
     }
 }
 
-impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
+impl<let N: u32, let NumSegments: u32> U60Repr<N, NumSegments> {
 
-    unconstrained fn new<let NumFieldSegments: u64>(x: ArrayX<Field, N, NumFieldSegments>) -> Self {
+    unconstrained fn new<let NumFieldSegments: u32>(x: ArrayX<Field, N, NumFieldSegments>) -> Self {
         let mut result: Self = U60Repr { limbs: ArrayX { segments: [[0; N]; NumSegments] } };
         for i in 0..(N * NumFieldSegments) {
             let (lo, hi) = split_bits::split_60_bits(x.get(i));
@@ -99,7 +99,7 @@ impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
         result
     }
 
-    unconstrained fn into_arrayX<let NumFieldSegments: u64>(x: U60Repr<N, NumSegments>) -> ArrayX<Field, N, NumFieldSegments> {
+    unconstrained fn into_arrayX<let NumFieldSegments: u32>(x: U60Repr<N, NumSegments>) -> ArrayX<Field, N, NumFieldSegments> {
         let mut result: ArrayX<Field, N, NumFieldSegments> = ArrayX { segments: [[0; N]; NumFieldSegments] };
         let two_pow_60: Field = 0x1000000000000000;
         for i in 0..(N * NumFieldSegments) {
@@ -131,7 +131,7 @@ impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
         result
     }
 
-    fn get_bit(self, bit: u64) -> bool {
+    fn get_bit(self, bit: u32) -> bool {
         let segment_index = bit / 60;
         let uint_index = bit % 60;
 
@@ -141,20 +141,20 @@ impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
     }
 
     // note: shr cannot satisfy `Shr` Trait due to `shift` parameter being u64 and not u8 (shift value might be greater than 255)
-    fn shr(self, shift: u64) -> Self {
+    fn shr(self, shift: u32) -> Self {
         let mut result: Self = U60Repr { limbs: ArrayX { segments: [[0; N]; NumSegments] } };
 
-        let num_shifted_limbs: u64 = shift / 60;
+        let num_shifted_limbs = shift / 60;
         let limb_shift = shift % 60;
         let remainder_shift = 60 - limb_shift;
         let mask: u64 = (((1 as u64) << limb_shift as u8) - 1) << remainder_shift as u8;
         result.limbs.set(
             0,
-            (self.limbs.get(0 + num_shifted_limbs as u64) >> limb_shift as u8)
+            (self.limbs.get(0 + num_shifted_limbs) >> limb_shift as u8)
         );
 
-        for i in 1..((N * NumSegments) - num_shifted_limbs) as u64 {
-            let value = self.limbs.get(i + num_shifted_limbs as u64);
+        for i in 1..((N * NumSegments) - num_shifted_limbs) {
+            let value = self.limbs.get(i + num_shifted_limbs);
             result.limbs.set(i, (value >> limb_shift as u8));
             let remainder: u64 = (value << remainder_shift as u8) & mask;
             result.limbs.set(i - 1, result.limbs.get(i - 1) + remainder);
@@ -179,10 +179,10 @@ impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
     }
 
     // note: shr cannot satisfy `Shr` Trait due to `shift` parameter being u64 and not u8 (shift value might be greater than 255)
-    fn shl(self, shift: u64) -> Self {
+    fn shl(self, shift: u32) -> Self {
         let mut result: Self = U60Repr { limbs: ArrayX { segments: [[0; N]; NumSegments] } };
 
-        let num_shifted_limbs: u64 = shift / 60;
+        let num_shifted_limbs = shift / 60;
         let limb_shift = (shift % 60) as u8;
         let remainder_shift: u8 = 60 - limb_shift as u8;
 
@@ -199,10 +199,10 @@ impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
 
         // shift 84. num shifted = 1
 
-        for i in 1..((N * NumSegments) - num_shifted_limbs) as u64 {
+        for i in 1..((N * NumSegments) - num_shifted_limbs) {
             let value = self.limbs.get(i);
             let upshift = ((value << limb_shift) + remainder) & mask;
-            result.limbs.set(i + num_shifted_limbs as u64, upshift);
+            result.limbs.set(i + num_shifted_limbs, upshift);
             remainder = (value >> remainder_shift);
             // let remainder: u64 = (self.limbs.get(i + num_shifted_limbs as u64) << remainder_shift as u8) & mask;
             // result.limbs.set(i - 1, result.limbs.get(i - 1) + remainder);
@@ -233,12 +233,13 @@ impl<let N: u64, let NumSegments: u64> U60Repr<N, NumSegments> {
         }
     }
 
-    unconstrained  fn get_msb(val: Self) -> u64 {
-        let mut count: u64 = 0;
+    unconstrained  fn get_msb(val: Self) -> u32 {
+        let mut count = 0;
         for i in 0..N * NumSegments {
             let v = val.limbs.get((N * NumSegments) - 1 - i);
             if (v > 0) {
                 count = 60 * ((N * NumSegments) - 1 - i) + get_msb64(v);
+                // count = 60 * ((N as u64 * NumSegments as u64) - 1 - i as u64) + get_msb64(v);
                 break;
             }
         }

--- a/src/utils/u60_representation.nr
+++ b/src/utils/u60_representation.nr
@@ -239,7 +239,6 @@ impl<let N: u32, let NumSegments: u32> U60Repr<N, NumSegments> {
             let v = val.limbs.get((N * NumSegments) - 1 - i);
             if (v > 0) {
                 count = 60 * ((N * NumSegments) - 1 - i) + get_msb64(v);
-                // count = 60 * ((N as u64 * NumSegments as u64) - 1 - i as u64) + get_msb64(v);
                 break;
             }
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5632

## Summary\*



## Additional Context



# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
