### PR TITLE
chore: add a canary for tests failing on nightly releases of nargo

### DIFF
--- a/.github/NIGHTLY_CANARY_DIED.md
+++ b/.github/NIGHTLY_CANARY_DIED.md
@@ -1,0 +1,8 @@
+---
+title: "Tests fail on latest Nargo nightly release"
+assignees: TomAFrench
+---
+
+The tests on this Noir project have started failing when using the latest nightly release of the Noir compiler. This likely means that there have been breaking changes for which this project needs to be updated to take into account.
+
+Check the [{{env.WORKFLOW_NAME}}]({{env.WORKFLOW_URL}}) workflow for details.

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -1,0 +1,40 @@
+name: Noir Nightly Canary
+
+on:
+  schedule:
+    # Run a check at 9 AM UTC
+    - cron: "0 9 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test on Nargo ${{matrix.toolchain}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nargo
+        uses: noir-lang/noirup@v0.1.3
+        with:
+          toolchain: nightly
+
+      - name: Run Noir tests
+        run: nargo test
+
+      - name: Run formatter
+        run: nargo fmt --check
+
+      - name: Alert on dead links
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/NIGHTLY_CANARY_DIED.md
+      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,15 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NARGO_VERSION: 0.32.0
 
 jobs:
   test:
+    name: Test on Nargo ${{matrix.toolchain}}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [nightly, 0.32.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -20,7 +24,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: $NARGO_VERSION
+          toolchain: ${{ matrix.toolchain }}
 
       - name: Run Noir tests
         run: nargo test
@@ -34,7 +38,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: $NARGO_VERSION
+          toolchain: 0.32.0
 
       - name: Run formatter
         run: nargo fmt --check


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a new workflow which runs the tests on nightly releases of nargo and raises an issue if they start failing.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
