### PR TITLE
fix: remove unnecessary generic from `ArrayX.__normalize_limbs()`

### DIFF
--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -283,7 +283,7 @@ impl<let N: u32, Params> BigNum<N, Params> where Params: BigNumParamsTrait<N> {
     }
 }
 
-impl<let N: u32, Params,> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInstance<N, Params> where Params: BigNumParamsTrait<N> {
+impl<let N: u32, Params> BigNumInstanceTrait<BigNum<N, Params>> for BigNumInstance<N, Params> where Params: BigNumParamsTrait<N> {
 
     fn modulus(self) -> BigNum<N, Params> { BigNum{ limbs: self.modulus } }
     fn __derive_from_seed<let SeedBytes: u32>(self, seed: [u8; SeedBytes]) -> BigNum<N, Params> {
@@ -1271,7 +1271,7 @@ impl<let N: u32, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
 
         for i in 0..NUM_PRODUCTS {
             lhs[i] = self.__add_linear_expression(lhs_terms[i], lhs_flags[i]);
-            rhs[i]= self.__add_linear_expression(rhs_terms[i], rhs_flags[i]);
+            rhs[i] = self.__add_linear_expression(rhs_terms[i], rhs_flags[i]);
         }
 
         let add: [Field; N] = self.__add_linear_expression(linear_terms, linear_flags);
@@ -1373,7 +1373,7 @@ impl<let N: u32, Params> BigNumInstance<N, Params> where Params: BigNumParamsTra
             linear_terms,
             linear_flags
         );
-        let mut mulout_n: ArrayX<Field, N,2> = ArrayX::new();
+        let mut mulout_n: ArrayX<Field, N, 2> = ArrayX::new();
 
         let relation_result: ArrayX<Field, N, 2> = mulout_p.__normalize_limbs(N + N);
         let modulus: [Field; N] = self.modulus;

--- a/src/utils/arrayX.nr
+++ b/src/utils/arrayX.nr
@@ -74,10 +74,13 @@ impl<T, let N: u32, let SizeMultiplier: u32> ArrayX<T, N, SizeMultiplier> {
         let index = i % N;
         self.segments[segment][index]
     }
+}
 
-    unconstrained fn __normalize_limbs<let NumSegments: u32>(x: ArrayX<Field, N, NumSegments>, range: u32) -> ArrayX<Field, N, NumSegments> {
-        let mut normalized: ArrayX<Field, N, NumSegments> = ArrayX::new();
-        let mut inp = x;
+impl<let N: u32, let SizeMultiplier: u32> ArrayX<Field, N, SizeMultiplier> {
+
+    unconstrained fn __normalize_limbs(self, range: u32) -> Self {
+        let mut normalized: Self = ArrayX::new();
+        let mut inp = self;
         // (9 limb mul = 17 product terms)
 
         // a2 a1 a0


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I've removed the generic from `ArrayX.__normalize_limbs()` and created a separate impl so that this method is only implemented for `ArrayX<Field, _, _>`

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
