### PR TITLE
fix: issue with bit check in `from_be_bytes`

### DIFF
--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -147,7 +147,7 @@ impl<let N: u32, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
     fn from_be_bytes<let NBytes: u32>(x: [u8; NBytes]) -> BigNum<N, Params> {
         let num_bits = NBytes * 8;
         let modulus_bits = Params::modulus_bits();
-        assert(num_bits > modulus_bits);
+        assert(num_bits >= modulus_bits);
         assert(num_bits - modulus_bits < 8);
         let mut result = BigNum::new();
 


### PR DESCRIPTION
# Description

Fixes an issue with the `from_be_bytes` preventing the use of the function when the number of bits of the bytes passed as argument is the same as the number of bits encoding the modulus.

## Problem\*

```rust
fn from_be_bytes<let NBytes: u32>(x: [u8; NBytes]) -> BigNum<N, Params> {
        let num_bits = NBytes * 8;
        let modulus_bits = Params::modulus_bits();
        assert(num_bits > modulus_bits);
        assert(num_bits - modulus_bits < 8);
        ...
}
```

In the original code, when `num_bits` yields the same value as `modulus_bits` the assert fails and the function is usuable.

## Summary\*

As this behavior is not desired, simply replacing the strictly greater than with a greater than or equal fixes the issue:

```rust
fn from_be_bytes<let NBytes: u32>(x: [u8; NBytes]) -> BigNum<N, Params> {
        let num_bits = NBytes * 8;
        let modulus_bits = Params::modulus_bits();
        assert(num_bits >= modulus_bits);
        assert(num_bits - modulus_bits < 8);
        ...
}
```

Which is what this PR changes.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
