### PR TITLE
chore: update to latest aztec-nargo

### DIFF
--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -187,12 +187,12 @@ impl<let N: u32, Params> BigNumTrait for BigNum<N, Params> where Params: BigNumP
 
         let mut result: [u8; NBytes] = [0; NBytes];
         for i in 0..N - 1 {
-            let limb_bytes = val.limbs[i].to_le_bytes(15);
+            let limb_bytes: [u8; 15] = val.limbs[i].to_le_bytes();
             for j in 0..15 {
                 result[i * 15 + j] = limb_bytes[j];
             }
         }
-        let last_limb_bytes = val.limbs[N - 1].to_le_bytes(15);
+        let last_limb_bytes: [u8; 15] = val.limbs[N - 1].to_le_bytes();
         let num_last_bytes = (NBytes - (N - 1) * 15);
         for i in 0..num_last_bytes {
             result[(N-1) * 15 + i] = last_limb_bytes[i];

--- a/src/utils/split_bits.nr
+++ b/src/utils/split_bits.nr
@@ -1,7 +1,7 @@
 
 // Decomposes a single field into two 120 bit fields and a carry
 unconstrained pub fn split_120_bits(x: Field) -> (Field, Field) {
-    let x_bytes: [u8] = x.to_le_bytes(32);
+    let x_bytes: [u8; 32] = x.to_le_bytes();
 
     let mut low: Field = 0;
     let mut high: Field = 0;
@@ -27,7 +27,7 @@ unconstrained pub fn split_120_bits(x: Field) -> (Field, Field) {
  * @description Expects the input limb to be in the range [0, ..., 2^{120 - 1}]
  **/
 unconstrained pub fn split_60_bits(x: Field) -> (u64, u64) {
-    let x_bytes = x.to_le_bytes(32);
+    let x_bytes: [u8; 32] = x.to_le_bytes();
 
     let mut low: u64 = 0;
     let mut high: u64 = 0;


### PR DESCRIPTION
# Description

Support latest Noir and latest `aztec-nargo`. Probably should be merged after Noir 0.34.0 is released

## Problem\*

`aztec-nargo` uses an unreleased Noir that introduced breaking changes to `.to_be_bytes` and `.to_le_bytes`. 

## Summary\*

Fix compilation errors.

## Additional Context

Use it today:

```toml
bignum = { tag = "v0.4.0", git = "https://github.com/olehmisar/noir-bignum" }
```

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
