### PR TITLE
chore: remove formatter from canary

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Run Noir tests
         run: nargo test
 
-      - name: Run formatter
-        run: nargo fmt --check
-
       - name: Alert on dead links
         uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}

--- a/src/utils/u60_representation.nr
+++ b/src/utils/u60_representation.nr
@@ -213,7 +213,7 @@ impl<let N: u32, let NumSegments: u32> U60Repr<N, NumSegments> {
         }
     }
 
-    unconstrained  fn get_msb(val: Self) -> u32 {
+    unconstrained fn get_msb(val: Self) -> u32 {
         let mut count = 0;
         for i in 0..N * NumSegments {
             let v = val.limbs[((N * NumSegments) - 1 - i)];


### PR DESCRIPTION
# Description

## Problem\*

Resolves #29 

## Summary\*

This PR removes the formatter from the nightly canary as changes to formatting doesn't indicate a breaking change/regression as the tests do.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
