### PR TITLE
fix: remove unnecessary generic

### DIFF
--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -29,7 +29,7 @@ pub(crate) unconstrained fn __validate_in_field_compute_borrow_flags<let N: u32,
     flags
 }
 
-pub(crate) unconstrained fn __validate_gt_remainder<let N: u32, let MOD_BITS: u32>(
+pub(crate) unconstrained fn __validate_gt_remainder<let N: u32>(
     lhs: [Field; N],
     rhs: [Field; N],
 ) -> ([Field; N], [bool; N], [bool; N]) {

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -222,7 +222,7 @@ pub(crate) unconstrained fn __div<let N: u32, let MOD_BITS: u32>(
 *      2. numerator % divisor = remainder
 *      3. divisor * quotient + remainder = numerator
 **/
-pub(crate) unconstrained fn __udiv_mod<let N: u32, let MOD_BITS: u32>(
+pub(crate) unconstrained fn __udiv_mod<let N: u32>(
     numerator: [Field; N],
     divisor: [Field; N],
 ) -> ([Field; N], [Field; N]) {


### PR DESCRIPTION
# Description

## Problem\*

Resolves #41 

## Summary\*

This generic is unnecessary and just causes errors when it can't be bound.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
