### PR TITLE
chore: move tests outside of impl

### DIFF
--- a/src/tests/runtime_bignum_test.nr
+++ b/src/tests/runtime_bignum_test.nr
@@ -3,12 +3,7 @@ use crate::params::{BigNumParams, BigNumParamsGetter};
 use crate::runtime_bignum::RuntimeBigNum;
 use crate::utils::u60_representation::U60Repr;
 
-use crate::fields::bls12_377Fq::BLS12_377_Fq_Params;
-use crate::fields::bls12_377Fr::BLS12_377_Fr_Params;
-use crate::fields::bls12_381Fq::BLS12_381_Fq_Params;
-use crate::fields::bls12_381Fr::BLS12_381_Fr_Params;
 use crate::fields::bn254Fq::BN254_Fq_Params;
-use crate::fields::secp256k1Fq::Secp256k1_Fq_Params;
 
 global TEST_2048_PARAMS: BigNumParams<18, 2048> = BigNumParams {
     has_multiplicative_inverse: false,
@@ -190,7 +185,7 @@ global TEST_2048_PARAMS: BigNumParams<18, 2048> = BigNumParams {
     ],
 };
 
-struct Test2048Params {}
+pub(crate) struct Test2048Params {}
 
 // See https://github.com/noir-lang/noir/issues/6172
 #[test]
@@ -207,39 +202,18 @@ impl BigNumParamsGetter<18, 2048> for Test2048Params {
 /**
  * @brief experimenting with macro madness and code generation to make some tests that apply to multiple BigNum parametrisations!
  **/
-comptime fn make_test(f: StructDefinition, N: Quoted, MOD_BITS: Quoted, typ: Quoted) -> Quoted {
-    let k = f.name();
-    let test_add = f"{typ}_{N}_{MOD_BITS}_test_add".quoted_contents();
-    let test_sub = f"{typ}_{N}_{MOD_BITS}_test_sub".quoted_contents();
-    let test_sub_modulus_limit = f"{typ}_{N}_{MOD_BITS}_test_sub_modulus_limit".quoted_contents();
-    let test_sub_modulus_underflow =
-        f"{typ}_{N}_{MOD_BITS}_test_sub_modulus_underflow".quoted_contents();
-    let test_add_modulus_limit = f"{typ}_{N}_{MOD_BITS}_test_add_modulus_limit".quoted_contents();
-    let test_add_modulus_overflow =
-        f"{typ}_{N}_{MOD_BITS}_test_add_modulus_overflow".quoted_contents();
-    let test_mul = f"{typ}_{N}_{MOD_BITS}_test_mul".quoted_contents();
-    let test_quadratic_expression =
-        f"{typ}_{N}_{MOD_BITS}_test_quadratic_expression".quoted_contents();
-    let assert_is_not_equal = f"{typ}_{N}_{MOD_BITS}_assert_is_not_equal".quoted_contents();
-    let assert_is_not_equal_fail =
-        f"{typ}_{N}_{MOD_BITS}_assert_is_not_equal_fail".quoted_contents();
-    let assert_is_not_equal_overloaded_lhs_fail =
-        f"{typ}_{N}_{MOD_BITS}_assert_is_not_equal_overloaded_lhs_fail".quoted_contents();
-    let assert_is_not_equal_overloaded_rhs_fail =
-        f"{typ}_{N}_{MOD_BITS}_assert_is_not_equal_overloaded_rhs_fail".quoted_contents();
-    let assert_is_not_equal_overloaded_fail =
-        f"{typ}_{N}_{MOD_BITS}_assert_is_not_equal_overloaded_fail".quoted_contents();
-    let test_derive = f"{typ}_{N}_{MOD_BITS}_test_derive".quoted_contents();
-    let test_eq = f"{typ}_{N}_{MOD_BITS}_test_eq".quoted_contents();
+comptime fn make_test(_m: Module, N: Quoted, MOD_BITS: Quoted, typ: Quoted) -> Quoted {
+    let RuntimeBigNum = quote { crate::RuntimeBigNum };
+    let U60Repr = quote { crate::utils::u60_representation::U60Repr };
+
     quote {
-impl $k {
 #[test]
-fn $test_add() {
+fn test_add() {
     let params = $typ ::get_params();
     
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe{ RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4]) };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe{ RuntimeBigNum::__derive_from_seed(params, [4, 5, 6, 7]) };
-    let one: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::one(params);
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe{ $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4]) };
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe{ $RuntimeBigNum::__derive_from_seed(params, [4, 5, 6, 7]) };
+    let one: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::one(params);
     a.validate_in_range();
     a.validate_in_field();
     b.validate_in_range();
@@ -259,13 +233,13 @@ fn $test_add() {
 }
 
 #[test]
-fn $test_sub() {
+fn test_sub() {
     let params = $typ ::get_params();
 
     // 0 - 1 should equal p - 1
-    let mut a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::new(params);
-    let mut b: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::one(params);
-    let mut expected: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: params.modulus, params };
+    let mut a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::new(params);
+    let mut b: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::one(params);
+    let mut expected: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: params.modulus, params };
 
     expected.limbs[0] -= 1; // p - 1
 
@@ -275,14 +249,14 @@ fn $test_sub() {
 
 
 #[test]
-fn $test_sub_modulus_limit() {
+fn test_sub_modulus_limit() {
     let params = $typ ::get_params();
     // if we underflow, maximum result should be ...
     // 0 - 1 = o-1
     // 0 - p = 0
-    let mut a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::new(params);
-    let mut b: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: params.modulus, params };
-    let mut expected: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::new(params);
+    let mut a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::new(params);
+    let mut b: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: params.modulus, params };
+    let mut expected: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::new(params);
 
     let result = a - b;
     assert(result == expected);
@@ -290,14 +264,14 @@ fn $test_sub_modulus_limit() {
 
 
 #[test(should_fail_with = "call to assert_max_bit_size")]
-fn $test_sub_modulus_underflow() {
+fn test_sub_modulus_underflow() {
     let params = $typ ::get_params();
 
     // 0 - (p + 1) is smaller than p and should produce unsatisfiable constraints
-    let mut a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::new(params);
-    let mut b: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: params.modulus, params };
+    let mut a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::new(params);
+    let mut b: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: params.modulus, params };
     b.limbs[0] += 1;
-    let mut expected: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::one(params);
+    let mut expected: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::one(params);
 
     let result = a - b;
 
@@ -305,49 +279,49 @@ fn $test_sub_modulus_underflow() {
 }
 
 #[test]
-fn $test_add_modulus_limit() {
+fn test_add_modulus_limit() {
     let params = $typ ::get_params();
 
     // p + 2^{modulus_bits()} - 1 should be the maximum allowed value fed into an add operation
     // when adding, if the result overflows the modulus, we conditionally subtract the modulus, producing 2^{254} -  1
     // this is the largest value that will satisfy the range check applied when constructing a bignum
-    let p: U60Repr<$N, 2> = U60Repr::from(params.modulus);
-    let one = unsafe{ U60Repr::one() };
+    let p: $U60Repr<$N, 2> = $U60Repr::from(params.modulus);
+    let one = unsafe{ $U60Repr::one() };
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(p), params };
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(p), params };
 
-    let two_pow_modulus_bits_minus_one: U60Repr<$N, 2> = unsafe{ one.shl($MOD_BITS) - one };
+    let two_pow_modulus_bits_minus_one: $U60Repr<$N, 2> = unsafe{ one.shl($MOD_BITS) - one };
 
-    let b: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(two_pow_modulus_bits_minus_one), params };
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(two_pow_modulus_bits_minus_one), params };
     let result = a + b;
     assert(result == b);
 }
 
 #[test(should_fail_with = "call to assert_max_bit_size")]
-fn $test_add_modulus_overflow() {
+fn test_add_modulus_overflow() {
     let params = $typ ::get_params();
 
-    let p : U60Repr<$N, 2> = U60Repr::from(params.modulus);
-    let one = unsafe{ U60Repr::one() };
+    let p : $U60Repr<$N, 2> = $U60Repr::from(params.modulus);
+    let one = unsafe{ $U60Repr::one() };
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(p + one), params };
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(p + one), params };
 
-    let mut two_pow_modulus_bits_minus_one: U60Repr<$N, 2> = unsafe{ one.shl($MOD_BITS) - one };
+    let mut two_pow_modulus_bits_minus_one: $U60Repr<$N, 2> = unsafe{ one.shl($MOD_BITS) - one };
 
-    let b: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(two_pow_modulus_bits_minus_one), params };
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(two_pow_modulus_bits_minus_one), params };
     let result = a + b;
     assert(result == b);
 }
 
 #[test]
-fn $test_mul() {
+fn test_mul() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [4, 5, 6, 7])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [4, 5, 6, 7])
     };
 
     let c = (a + b) * (a + b);
@@ -356,16 +330,16 @@ fn $test_mul() {
 }
 
 #[test]
-fn $test_quadratic_expression() {
+fn test_quadratic_expression() {
     let params = $typ ::get_params();
 
     for i in 0..32 {
-        let X1: RuntimeBigNum<$N, $MOD_BITS> = unsafe{ RuntimeBigNum::__derive_from_seed(params, [i as u8, 2, 3, 4]) };
-        let Y1: RuntimeBigNum<$N, $MOD_BITS> = unsafe{ RuntimeBigNum::__derive_from_seed(params, [i as u8, i as u8, 6, 7]) };
-        let Z1: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::one(params);
+        let X1: $RuntimeBigNum<$N, $MOD_BITS> = unsafe{ $RuntimeBigNum::__derive_from_seed(params, [i as u8, 2, 3, 4]) };
+        let Y1: $RuntimeBigNum<$N, $MOD_BITS> = unsafe{ $RuntimeBigNum::__derive_from_seed(params, [i as u8, i as u8, 6, 7]) };
+        let Z1: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::one(params);
 
-        let (_, YY_mul_2): (RuntimeBigNum<$N, $MOD_BITS>, RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ RuntimeBigNum::__compute_quadratic_expression(params, [[Y1]], [[false]], [[Y1, Y1]], [[false, false]], [], []) };
-        let mut (_, XX_mul_3): (RuntimeBigNum<$N, $MOD_BITS>, RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ RuntimeBigNum::__compute_quadratic_expression(
+        let (_, YY_mul_2): ($RuntimeBigNum<$N, $MOD_BITS>, $RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ $RuntimeBigNum::__compute_quadratic_expression(params, [[Y1]], [[false]], [[Y1, Y1]], [[false, false]], [], []) };
+        let mut (_, XX_mul_3): ($RuntimeBigNum<$N, $MOD_BITS>, $RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ $RuntimeBigNum::__compute_quadratic_expression(
             params,
             [[X1]],
             [[false]],
@@ -374,8 +348,8 @@ fn $test_quadratic_expression() {
             [],
             []
         ) };
-        let (_, D): (RuntimeBigNum<$N, $MOD_BITS>, RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ RuntimeBigNum::__compute_quadratic_expression(params, [[X1, X1]], [[false, false]], [[YY_mul_2]], [[false]], [], []) };
-        let mut (_, X3) = unsafe{ RuntimeBigNum::__compute_quadratic_expression(
+        let (_, D): ($RuntimeBigNum<$N, $MOD_BITS>, $RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ $RuntimeBigNum::__compute_quadratic_expression(params, [[X1, X1]], [[false, false]], [[YY_mul_2]], [[false]], [], []) };
+        let mut (_, X3) = unsafe{ $RuntimeBigNum::__compute_quadratic_expression(
             params,
             [[XX_mul_3]],
             [[false]],
@@ -384,7 +358,7 @@ fn $test_quadratic_expression() {
             [D, D],
             [true, true]
         ) };
-        let (_, Y3): (RuntimeBigNum<$N, $MOD_BITS>, RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ RuntimeBigNum::__compute_quadratic_expression(
+        let (_, Y3): ($RuntimeBigNum<$N, $MOD_BITS>, $RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ $RuntimeBigNum::__compute_quadratic_expression(
             params,
             [[XX_mul_3], [YY_mul_2]],
             [[false], [true]],
@@ -395,7 +369,7 @@ fn $test_quadratic_expression() {
         ) };
         // 3XX * (D - X3) - 8YYYY
 
-        let (_, Z3): (RuntimeBigNum<$N, $MOD_BITS>, RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ RuntimeBigNum::__compute_quadratic_expression(params, [[Y1]], [[false]], [[Z1, Z1]], [[false, false]], [], []) };
+        let (_, Z3): ($RuntimeBigNum<$N, $MOD_BITS>, $RuntimeBigNum<$N, $MOD_BITS>) = unsafe{ $RuntimeBigNum::__compute_quadratic_expression(params, [[Y1]], [[false]], [[Z1, Z1]], [[false, false]], [], []) };
 
         X3.validate_in_field();
         Y3.validate_in_field();
@@ -404,130 +378,130 @@ fn $test_quadratic_expression() {
 }
 
 #[test]
-fn $assert_is_not_equal() {
+fn assert_is_not_equal() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [4, 5, 6, 7])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [4, 5, 6, 7])
     };
 
     a.assert_is_not_equal(b);
 }
 
 #[test(should_fail_with = "asssert_is_not_equal fail")]
-fn $assert_is_not_equal_fail() {
+fn assert_is_not_equal_fail() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
 
     a.assert_is_not_equal(b);
 }
 
 #[test(should_fail_with = "asssert_is_not_equal fail")]
-fn $assert_is_not_equal_overloaded_lhs_fail() {
+fn assert_is_not_equal_overloaded_lhs_fail() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
 
     let modulus = params.modulus;
 
-    let t0: U60Repr<$N, 2> = U60Repr::from(a.limbs);
-    let t1: U60Repr<$N, 2> = U60Repr::from(modulus);
-    let a_plus_modulus: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(t0 + t1), params };
+    let t0: $U60Repr<$N, 2> = $U60Repr::from(a.limbs);
+    let t1: $U60Repr<$N, 2> = $U60Repr::from(modulus);
+    let a_plus_modulus: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(t0 + t1), params };
 
     a_plus_modulus.assert_is_not_equal(b);
 }
 
 #[test(should_fail_with = "asssert_is_not_equal fail")]
-fn $assert_is_not_equal_overloaded_rhs_fail() {
+fn assert_is_not_equal_overloaded_rhs_fail() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
 
     let modulus = params.modulus;
 
-    let t0: U60Repr<$N, 2> = U60Repr::from(b.limbs);
-    let t1: U60Repr<$N, 2> = U60Repr::from(modulus);
-    let b_plus_modulus: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(t0 + t1), params };
+    let t0: $U60Repr<$N, 2> = $U60Repr::from(b.limbs);
+    let t1: $U60Repr<$N, 2> = $U60Repr::from(modulus);
+    let b_plus_modulus: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(t0 + t1), params };
 
     a.assert_is_not_equal(b_plus_modulus);
 }
 
 #[test(should_fail_with = "asssert_is_not_equal fail")]
-fn $assert_is_not_equal_overloaded_fail() {
+fn assert_is_not_equal_overloaded_fail() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
 
     let modulus = params.modulus;
 
-    let t0: U60Repr<$N, 2> = U60Repr::from(a.limbs);
-    let t1: U60Repr<$N, 2> = U60Repr::from(b.limbs);
-    let t2: U60Repr<$N, 2> = U60Repr::from(modulus);
+    let t0: $U60Repr<$N, 2> = $U60Repr::from(a.limbs);
+    let t1: $U60Repr<$N, 2> = $U60Repr::from(b.limbs);
+    let t2: $U60Repr<$N, 2> = $U60Repr::from(modulus);
 
-    let a_plus_modulus: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(t0 + t2), params };
-    let b_plus_modulus: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(t1 + t2), params };
+    let a_plus_modulus: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(t0 + t2), params };
+    let b_plus_modulus: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(t1 + t2), params };
 
     a_plus_modulus.assert_is_not_equal(b_plus_modulus);
 }
 
 #[test]
-fn $test_derive()
+fn test_derive()
 {
     let params = $typ ::get_params();
 
-    // let a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::derive_from_seed(params, "hello".as_bytes());
-    let a: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum::derive_from_seed(params, [1, 2, 3, 4]);
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        // RuntimeBigNum::__derive_from_seed(params, "hello".as_bytes())
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4]) 
+    // let a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::derive_from_seed(params, "hello".as_bytes());
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::derive_from_seed(params, [1, 2, 3, 4]);
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        // $RuntimeBigNum::__derive_from_seed(params, "hello".as_bytes())
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4]) 
     };
     assert_eq(a, b);
 }
 
 #[test]
-fn $test_eq() {
+fn test_eq() {
     let params = $typ ::get_params();
 
-    let a: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let a: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let b: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
+    let b: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [1, 2, 3, 4])
     };
-    let c: RuntimeBigNum<$N, $MOD_BITS> = unsafe {
-        RuntimeBigNum::__derive_from_seed(params, [2, 2, 3, 4])
+    let c: $RuntimeBigNum<$N, $MOD_BITS> = unsafe {
+        $RuntimeBigNum::__derive_from_seed(params, [2, 2, 3, 4])
     };
 
     let modulus = a.modulus();
 
-    let t0: U60Repr<$N, 2> = (U60Repr::from(modulus.limbs));
-    let t1: U60Repr<$N, 2> = (U60Repr::from(b.limbs));
+    let t0: $U60Repr<$N, 2> = ($U60Repr::from(modulus.limbs));
+    let t1: $U60Repr<$N, 2> = ($U60Repr::from(b.limbs));
 
-    let b_plus_modulus: RuntimeBigNum<$N, $MOD_BITS> = RuntimeBigNum { limbs: U60Repr::into(t0 + t1), params };
+    let b_plus_modulus: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum { limbs: $U60Repr::into(t0 + t1), params };
 
     assert((a == b) == true);
     assert((a == b_plus_modulus) == true);
@@ -537,28 +511,27 @@ fn $test_eq() {
 
 }
 }
-}
 
-#[make_test(quote{3}, quote{254}, quote{BN254_Fq_Params})]
-pub struct BNTests {}
+#[make_test(quote {3}, quote {254}, quote {crate::fields::bn254Fq::BN254_Fq_Params})]
+pub mod BNTests {}
 
-#[make_test(quote{3}, quote{256}, quote{Secp256k1_Fq_Params})]
-pub struct Secp256K1FqTests {}
+#[make_test(quote {3}, quote {256}, quote {crate::fields::secp256k1Fq::Secp256k1_Fq_Params})]
+pub mod Secp256K1FqTests {}
 
-#[make_test(quote{4}, quote{381} ,quote{BLS12_381_Fq_Params})]
-pub struct BLS12_381FqTests {}
+#[make_test(quote {4}, quote {381}, quote {crate::fields::bls12_381Fq::BLS12_381_Fq_Params})]
+pub mod BLS12_381FqTests {}
 
-#[make_test(quote{18}, quote{2048}, quote{Test2048Params})]
-pub struct Test2048Tests {}
+#[make_test(quote {18}, quote {2048}, quote {super::Test2048Params})]
+pub mod Test2048Tests {}
 
-#[make_test(quote{3}, quote{255}, quote{BLS12_381_Fr_Params})]
-pub struct BLS12_381_Fr_ParamsTests {}
+#[make_test(quote {3}, quote {255}, quote {crate::fields::bls12_381Fr::BLS12_381_Fr_Params})]
+pub mod BLS12_381_Fr_ParamsTests {}
 
-#[make_test(quote{4}, quote{377}, quote{BLS12_377_Fq_Params})]
-pub struct BLS12_377_Fq_ParamsTests {}
+#[make_test(quote {4}, quote {377}, quote {crate::fields::bls12_377Fq::BLS12_377_Fq_Params})]
+pub mod BLS12_377_Fq_ParamsTests {}
 
-#[make_test(quote{3}, quote{253}, quote{BLS12_377_Fr_Params})]
-pub struct BLS12_377_Fr_ParamsTests {}
+#[make_test(quote {3}, quote {253}, quote {crate::fields::bls12_377Fr::BLS12_377_Fr_Params})]
+pub mod BLS12_377_Fr_ParamsTests {}
 
 // 98760
 // 99689


### PR DESCRIPTION
# Description

## Problem

Noir we'll soon error if using `#[test]` on an impl method.

## Summary

This PR changes the `make_test` macro and its calls to define the methods inside a module.

I decided to make the test names be "simple" again because now the full name will be different because tests live inside different modules.

## Additional Context

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
