### PR TITLE
fix: typos in documentation files

### DIFF
--- a/migration_notes.md
+++ b/migration_notes.md
@@ -2,7 +2,7 @@
 
 This lib got a big refactor for release 0.4.0.
 
-Here's a summary of changes that will hopefull help you update.
+Here's a summary of changes that will hopefully help you update.
 
 For a quick overview, see the updated [README](./README.md).
 
@@ -12,7 +12,7 @@ Previously, a BigNum type was declared as:
 
 `type MyBigNum = BigNum<3, MyParams>;`
 
-where `3` was the number of limbs of your bignum, and `MyParams` is either a prebuild struct of `Params` from the `fields/` dir of this library, or your own custom set of params.
+where `3` was the number of limbs of your bignum, and `MyParams` is either a pre-build struct of `Params` from the `fields/` dir of this library, or your own custom set of params.
 
 Now, we need to also specify an extra param: the number of bits in the modulus.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "hopefull" to "hopefully".
Corrected "prebuild" to "pre-build".

Please review the changes and let me know if any additional changes are needed.