### PR TITLE
chore: test against noir 1.0.0-beta.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.36.0]
+        toolchain: [nightly, 0.36.0, 1.0.0-beta.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're looking to flip `1.0.0-beta.0` to an official release so we should test compatibility with it.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
