### PR TITLE
fix: Noir 1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 1.0.0-beta.0]
+        toolchain: [nightly, 0.36.0, 1.0.0-beta.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.0
+          toolchain: 0.36.0
 
       - name: Run formatter
         run: nargo fmt --check

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,6 +2,6 @@
 name = "bignum"
 type = "lib"
 authors = [""]
-compiler_version = "1.0.0"
+compiler_version = ">=0.36.0"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ bignum can evaluate large integer arithmetic by defining a modulus() that is a p
 
 TODO
 
+## Noir Version Compatibility
+
+Workflows include tests for the following Noir versions.
+
+- 0.36.0
+- 1.0.0-beta.0
+- nightly
+
 ## Dependencies
 
 - Noir ≥v0.36.0

--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -6,8 +6,7 @@ use crate::fns::{
     constrained_ops::{
         add, assert_is_not_equal, conditional_select, derive_from_seed, div, eq, mul, neg, sub,
         udiv, udiv_mod, umod, validate_in_field, validate_in_range,
-    },
-    expressions::{__compute_quadratic_expression, evaluate_quadratic_expression},
+    }, expressions::{__compute_quadratic_expression, evaluate_quadratic_expression},
     serialization::{from_be_bytes, to_le_bytes},
     unconstrained_ops::{
         __add, __batch_invert, __batch_invert_slice, __derive_from_seed, __div, __eq, __invmod,

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -5,8 +5,7 @@ use crate::fns::{
     unconstrained_helpers::{
         __add_with_flags, __neg_with_flags, __sub_with_flags, __validate_gt_remainder,
         __validate_in_field_compute_borrow_flags,
-    },
-    unconstrained_ops::{__div, __mul, __udiv_mod},
+    }, unconstrained_ops::{__div, __mul, __udiv_mod},
 };
 
 /**

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -5,8 +5,7 @@ use crate::fns::{
     constrained_ops::{
         add, assert_is_not_equal, conditional_select, derive_from_seed, div, eq, mul, neg, sub,
         udiv, udiv_mod, umod, validate_in_field, validate_in_range,
-    },
-    expressions::{__compute_quadratic_expression, evaluate_quadratic_expression},
+    }, expressions::{__compute_quadratic_expression, evaluate_quadratic_expression},
     serialization::{from_be_bytes, to_le_bytes},
     unconstrained_ops::{
         __add, __batch_invert, __batch_invert_slice, __derive_from_seed, __div, __eq, __invmod,


### PR DESCRIPTION
# Description

there are a few things here. the changes to the repo are as follows.

- `Nargo.toml` config: revert minimum compiler version to 0.36.0
- workflow: revert to version 0.36.0 for `nargo fmt`
- workflow: add tests for Noir vesions:
  - 0.36.0
  - nightly
  - 1.0.0-beta.0
- readme: add some version compatibility documentation
- src: ran `nargo fmt` with 0.36.0

the reason for the reverts is because of an erroneous commit (#66), where i incorrectly migrated to the compiler version 1.0.0-beta.0

so ultimately, we only had to add the new version to the testing suite and document it. that is what this achieves in the aftermath of the previous commit.

## Problem\*

this closes #65

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
