### PR TITLE
chore: remove references to barretenberg in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ TODO
 
 This library is tested with all stable releases since 0.36.0 as well as nightly.
 
-## Dependencies
-
-- Noir ≥v0.36.0
-- Barretenberg ≥v0.56.1
-
 Refer to [Noir's docs](https://noir-lang.org/docs/getting_started/installation/) and [Barretenberg's docs](https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/cpp/src/barretenberg/bb/readme.md#installation) for installation steps.
 
 ## Installation


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

Listing a noir version as a dependency is redundant with describing which versions the library is tested against. References to barretenberg are not useful here and just add more info which will fall out of sync, e.g. https://github.com/noir-lang/noir-bignum/pull/84

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
