### PR TITLE
feat: added `to_field` method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MINIMUM_NOIR_VERSION: v1.0.0-beta.0
+  MINIMUM_NOIR_VERSION: v0.36.0
 
 jobs:
   noir-version-list:
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       noir_versions: ${{ steps.get_versions.outputs.versions }}
+
     steps:
       - name: Checkout sources
         id: get_versions
-        run: |
+        run: |         
           # gh returns the Noir releases in reverse chronological order so we keep all releases published after the minimum supported version.
           VERSIONS=$(gh release list -R noir-lang/noir --exclude-pre-releases --json tagName -q 'map(.tagName) | index(env.MINIMUM_NOIR_VERSION) as $index | if $index then .[0:$index+1] else [env.MINIMUM_NOIR_VERSION] end')
           echo "versions=$VERSIONS"
@@ -50,6 +51,7 @@ jobs:
         run: nargo test
 
   format:
+    needs: [noir-version-list]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -58,13 +60,11 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: ${{ env.MINIMUM_NOIR_VERSION }}
-
+          toolchain: ${{needs.noir-version-list.outputs.noir_versions[0] }}
       - name: Run formatter
         run: nargo fmt --check
 
-
-# This is a job which depends on all test jobs and reports the overall status.
+  # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.
   tests-end:
     name: Noir End

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,6 +2,6 @@
 name = "bignum"
 type = "lib"
 authors = [""]
-compiler_version = ">=1.0.0"
+compiler_version = ">=0.36.0"
 
 [dependencies]

--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -5,7 +5,7 @@ use crate::params::BigNumParamsGetter;
 use crate::fns::{
     constrained_ops::{
         add, assert_is_not_equal, conditional_select, derive_from_seed, div, eq, from_field, mul,
-        neg, sub, udiv, udiv_mod, umod, validate_in_field, validate_in_range,
+        neg, sub, udiv, udiv_mod, umod, validate_in_field, validate_in_range, to_field
     },
     expressions::{__compute_quadratic_expression, evaluate_quadratic_expression},
     serialization::{from_be_bytes, to_le_bytes},
@@ -31,6 +31,7 @@ pub trait BigNumTrait: Neg + Add + Sub + Mul + Div + Eq {
     pub fn from_slice(limbs: [Field]) -> Self;
     pub fn from_be_bytes<let NBytes: u32>(x: [u8; NBytes]) -> Self;
     pub fn to_le_bytes<let NBytes: u32>(self) -> [u8; NBytes];
+    pub fn to_field(self) -> Field;
 
     pub fn modulus() -> Self;
     pub fn modulus_bits(self) -> u32;
@@ -136,6 +137,11 @@ where
     fn from_slice(limbs: [Field]) -> Self {
         Self { limbs: limbs.as_array() }
     }
+
+    pub fn to_field(self) -> Field {
+    to_field::<_, MOD_BITS>(Params::get_params(), self.limbs)
+    }
+
 
     fn from_be_bytes<let NBytes: u32>(x: [u8; NBytes]) -> Self {
         Self { limbs: from_be_bytes::<_, MOD_BITS, _>(x) }

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -35,6 +35,37 @@ use crate::params::BigNumParams as P;
 * We use a hash function that can be modelled as a random oracle
 * This function *should* produce an output that is a uniformly randomly distributed value modulo BigNum::modulus()
 **/
+pub(crate) fn to_field<let N: u32, let MOD_BITS: u32>(
+    params: P<N, MOD_BITS>,
+    limbs: [Field; N],
+) -> Field {
+    let TWO_POW_120 = 0x1000000000000000000000000000000;
+    // let mut field: Field = 0;
+    if N > 2 {
+        // validate that the limbs is less than the modulus the grumpkin modulus
+        let mut grumpkin_modulus = [0; N];
+        grumpkin_modulus[0] = 0x33e84879b9709143e1f593f0000001;
+        grumpkin_modulus[1] = 0x4e72e131a029b85045b68181585d28;
+        grumpkin_modulus[2] = 0x3064;
+        validate_gt::<N, 254>(grumpkin_modulus, limbs);
+        // validate that the limbs are in range
+        validate_in_range::<N, 254>(limbs);
+    }
+    // validate the limbs sum up to the field value
+    let field_val = if N < 2 {
+        limbs[0]
+    } else if N == 2 {
+        validate_in_range::<N, 254>(limbs);
+        limbs[0] + limbs[1] * TWO_POW_120
+    } else {
+        validate_in_range::<N, 254>(limbs);
+        limbs[0] + limbs[1] * TWO_POW_120 + limbs[2] * TWO_POW_120 * TWO_POW_120
+    };
+    field_val 
+    // assert that the conversion is possible, i.e. the bignum is less than grumpkin field modulus 
+
+}
+
 pub(crate) fn from_field<let N: u32, let MOD_BITS: u32>(
     params: P<N, MOD_BITS>,
     field: Field,

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -816,3 +816,59 @@ fn test_from_field_3_digits() {
     assert(result == expected);
 }
 
+
+
+
+#[test]
+fn test_to_field_one() {
+    let field: Field = 1;
+    let bn = Fq::one(); 
+    let result = bn.to_field();
+    assert(result == field);
+}
+
+#[test]
+fn test_to_field_one_digit() {
+    let field: Field = 1066513542066841864585910935480267774;
+    let bn = Fq { limbs: [0xcd672d695ef3129e4c40867a7173fe, 0x0, 0x0] };
+    let result = bn.to_field();
+    assert(result == field);
+}
+
+#[test]
+fn test_to_field_two_digits() {
+    let field: Field = 697955470585821007263499235110798476786097877002667034107578965871052378; 
+    let bn = Fq { limbs: [0x5a10b956d41840745e0a9f6e34465a, 0x65209b74583b912262843211905e41,
+    0x0] };
+    let result = bn.to_field();
+    assert(result == field);
+
+}
+
+#[test]
+fn test_to_field_three_digits() {
+    let field: Field = 2330301921655783950764183713945533646391233209687308929386184468126823563744; 
+    let bn = Fq { limbs: [0x862cf8ea69d6c70c9cc8d8871b41e0, 0xe7763528201566c2fc8d93973cf1b4,
+    0x526] };
+    let result = bn.to_field();
+    assert(result == field);
+
+}
+
+#[test(should_fail_with = "BigNum::validate_gt check fails")]
+fn test_to_field_three_digits_overflow() {
+    let bn: Fq = BigNum { limbs: [0x4e6405505a33bb9b9c0563df2bd59a,
+    0x48dbe03a9bb4865ba961e41ef9dded, 0x3a36] };
+    let result = bn.to_field();
+}
+
+#[test(should_fail_with = "BigNum::validate_gt check fails")]
+fn test_to_field_too_many_digits() {
+    let bn: BN381 = BN381 {
+        limbs: [0xea1742447ee9d92f9f18e1c80a481e, 0x3d89ad3d3ae85f3f482a08435c93ec,
+        0x1e9f, 0x1]
+    };
+    let result = bn.to_field();
+}
+
+


### PR DESCRIPTION
# Description
added a method that allows casting bignums to `Field` type given the bignum is in range. 
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
