### PR TITLE
feat: constrain ops only in constrained context

### DIFF
--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -432,16 +432,19 @@ pub(crate) fn mul<let N: u32, let MOD_BITS: u32>(
     lhs: [Field; N],
     rhs: [Field; N],
 ) -> [Field; N] {
+    /// Safety: `result` is checked by `evaluate_quadratic_expression`
     let result = unsafe { __mul::<_, MOD_BITS>(params, lhs, rhs) };
-    evaluate_quadratic_expression(
-        params,
-        [[lhs]],
-        [[false]],
-        [[rhs]],
-        [[false]],
-        [result],
-        [true],
-    );
+    if !std::runtime::is_unconstrained() {
+        evaluate_quadratic_expression(
+            params,
+            [[lhs]],
+            [[false]],
+            [[rhs]],
+            [[false]],
+            [result],
+            [true],
+        );
+    }
     result
 }
 
@@ -455,21 +458,24 @@ pub(crate) fn div<let N: u32, let MOD_BITS: u32>(
         params.has_multiplicative_inverse,
         "BigNum has no multiplicative inverse. Use udiv for unsigned integer division",
     );
+    /// Safety: `result` is checked by `evaluate_quadratic_expression`
     let result = unsafe { __div::<_, MOD_BITS>(params, lhs, rhs) };
-    evaluate_quadratic_expression(
-        params,
-        [[result]],
-        [[false]],
-        [[rhs]],
-        [[false]],
-        [lhs],
-        [true],
-    );
+    if !std::runtime::is_unconstrained() {
+        evaluate_quadratic_expression(
+            params,
+            [[result]],
+            [[false]],
+            [[rhs]],
+            [[false]],
+            [lhs],
+            [true],
+        );
+    }
     result
 }
 
 /**
-* @brief udiv_mod performs integer division between numerator, divisor 
+* @brief udiv_mod performs integer division between numerator, divisor
 *
 * i.e. 1. floor(numerator / divisor) = quotient
 *      2. numerator % divisor = remainder
@@ -480,19 +486,22 @@ pub(crate) fn udiv_mod<let N: u32, let MOD_BITS: u32>(
     numerator: [Field; N],
     divisor: [Field; N],
 ) -> ([Field; N], [Field; N]) {
+    /// Safety: `quotient` and `remainder` are checked by `evaluate_quadratic_expression`
     let (quotient, remainder) = unsafe { __udiv_mod(numerator, divisor) };
 
-    // self / divisor = quotient rounded
-    // quotient * divisor + remainder - self = 0
-    evaluate_quadratic_expression(
-        params,
-        [[quotient]],
-        [[false]],
-        [[divisor]],
-        [[false]],
-        [numerator, remainder],
-        [true, false],
-    );
+    if !std::runtime::is_unconstrained() {
+        // self / divisor = quotient rounded
+        // quotient * divisor + remainder - self = 0
+        evaluate_quadratic_expression(
+            params,
+            [[quotient]],
+            [[false]],
+            [[divisor]],
+            [[false]],
+            [numerator, remainder],
+            [true, false],
+        );
+    }
     // we need (remainder < divisor)
     // implies (divisor - remainder > 0)
     validate_gt::<_, MOD_BITS>(divisor, remainder);
@@ -500,7 +509,7 @@ pub(crate) fn udiv_mod<let N: u32, let MOD_BITS: u32>(
 }
 
 /**
-* @brief udiv_mod performs integer division between numerator, divisor 
+* @brief udiv_mod performs integer division between numerator, divisor
 *
 * i.e. return param is floor(numerator / divisor)
 **/
@@ -524,4 +533,3 @@ pub(crate) fn umod<let N: u32, let MOD_BITS: u32>(
 ) -> [Field; N] {
     udiv_mod::<_, MOD_BITS>(params, numerator, divisor).1
 }
-

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -4,7 +4,7 @@ use crate::fns::{
         __add_with_flags, __from_field, __neg_with_flags, __sub_with_flags, __validate_gt_remainder,
         __validate_in_field_compute_borrow_flags,
     },
-    unconstrained_ops::{__div, __mul, __udiv_mod},
+    unconstrained_ops::{__add, __div, __mul, __neg, __sub, __udiv_mod},
 };
 use crate::params::BigNumParams as P;
 
@@ -35,31 +35,34 @@ pub(crate) fn from_field<let N: u32, let MOD_BITS: u32>(
     // safty: we check that the resulting limbs represent the intended field element
     // we check the bit length, the limbs being max 120 bits, and the value in total is less than the field modulus
     let result = unsafe { __from_field::<N>(field) };
-    // validate the limbs are in range and the value in total is less than 2^254
 
-    let TWO_POW_120 = 0x1000000000000000000000000000000;
-    // validate that the last limb is less than the modulus
-    if N > 2 {
-        // validate that the result is less than the modulus
-        let mut grumpkin_modulus = [0; N];
-        grumpkin_modulus[0] = 0x33e84879b9709143e1f593f0000001;
-        grumpkin_modulus[1] = 0x4e72e131a029b85045b68181585d28;
-        grumpkin_modulus[2] = 0x3064;
-        validate_gt::<N, 254>(grumpkin_modulus, result);
-        // validate that the limbs are in range
-        validate_in_range::<N, 254>(result);
+    if !std::runtime::is_unconstrained() {
+        // validate the limbs are in range and the value in total is less than 2^254
+
+        let TWO_POW_120 = 0x1000000000000000000000000000000;
+        // validate that the last limb is less than the modulus
+        if N > 2 {
+            // validate that the result is less than the modulus
+            let mut grumpkin_modulus = [0; N];
+            grumpkin_modulus[0] = 0x33e84879b9709143e1f593f0000001;
+            grumpkin_modulus[1] = 0x4e72e131a029b85045b68181585d28;
+            grumpkin_modulus[2] = 0x3064;
+            validate_gt::<N, 254>(grumpkin_modulus, result);
+            // validate that the limbs are in range
+            validate_in_range::<N, 254>(result);
+        }
+        // validate the limbs sum up to the field value
+        let field_val = if N < 2 {
+            result[0]
+        } else if N == 2 {
+            validate_in_range::<N, 254>(result);
+            result[0] + result[1] * TWO_POW_120
+        } else {
+            validate_in_range::<N, 254>(result);
+            result[0] + result[1] * TWO_POW_120 + result[2] * TWO_POW_120 * TWO_POW_120
+        };
+        assert(field_val == field);
     }
-    // validate the limbs sum up to the field value
-    let field_val = if N < 2 {
-        result[0]
-    } else if N == 2 {
-        validate_in_range::<N, 254>(result);
-        result[0] + result[1] * TWO_POW_120
-    } else {
-        validate_in_range::<N, 254>(result);
-        result[0] + result[1] * TWO_POW_120 + result[2] * TWO_POW_120 * TWO_POW_120
-    };
-    assert(field_val == field);
     result
 }
 
@@ -333,21 +336,30 @@ pub(crate) fn neg<let N: u32, let MOD_BITS: u32>(
     params: P<N, MOD_BITS>,
     val: [Field; N],
 ) -> [Field; N] {
-    // so we do... p - x - r = 0 and there might be borrow flags
-    let (result, borrow_flags) = unsafe { __neg_with_flags(params, val) };
-    validate_in_range::<_, MOD_BITS>(result);
-    let modulus = params.modulus;
-    let borrow_shift = 0x1000000000000000000000000000000;
-    let result_limb = modulus[0] - val[0] - result[0] + (borrow_flags[0] as Field * borrow_shift);
-    assert(result_limb == 0);
-    for i in 1..N - 1 {
-        let result_limb = modulus[i] - val[i] - result[i] - borrow_flags[i - 1] as Field
-            + (borrow_flags[i] as Field * borrow_shift);
+    if std::runtime::is_unconstrained() {
+        // Safety: not need to constrain in unconstrained runtime
+        unsafe {
+            __neg(params, val)
+        }
+    } else {
+        // so we do... p - x - r = 0 and there might be borrow flags
+        let (result, borrow_flags) = unsafe { __neg_with_flags(params, val) };
+        validate_in_range::<_, MOD_BITS>(result);
+        let modulus = params.modulus;
+        let borrow_shift = 0x1000000000000000000000000000000;
+        let result_limb =
+            modulus[0] - val[0] - result[0] + (borrow_flags[0] as Field * borrow_shift);
         assert(result_limb == 0);
+        for i in 1..N - 1 {
+            let result_limb = modulus[i] - val[i] - result[i] - borrow_flags[i - 1] as Field
+                + (borrow_flags[i] as Field * borrow_shift);
+            assert(result_limb == 0);
+        }
+        let result_limb =
+            modulus[N - 1] - val[N - 1] - result[N - 1] - borrow_flags[N - 2] as Field;
+        assert(result_limb == 0);
+        result
     }
-    let result_limb = modulus[N - 1] - val[N - 1] - result[N - 1] - borrow_flags[N - 2] as Field;
-    assert(result_limb == 0);
-    result
 }
 
 pub(crate) fn add<let N: u32, let MOD_BITS: u32>(
@@ -355,35 +367,45 @@ pub(crate) fn add<let N: u32, let MOD_BITS: u32>(
     lhs: [Field; N],
     rhs: [Field; N],
 ) -> [Field; N] {
-    // so we do... p - x - r = 0 and there might be borrow flags
-    let (result, carry_flags, borrow_flags, overflow_modulus) =
-        unsafe { __add_with_flags(params, lhs, rhs) };
-    validate_in_range::<_, MOD_BITS>(result);
-    let modulus = params.modulus;
-    let borrow_shift = 0x1000000000000000000000000000000;
-    let carry_shift = 0x1000000000000000000000000000000;
+    if std::runtime::is_unconstrained() {
+        // Safety: not need to constrain in unconstrained runtime
+        unsafe {
+            __add(params, lhs, rhs)
+        }
+    } else {
+        // so we do... p - x - r = 0 and there might be borrow flags
+        let (result, carry_flags, borrow_flags, overflow_modulus) =
+            unsafe { __add_with_flags(params, lhs, rhs) };
+        validate_in_range::<_, MOD_BITS>(result);
+        let modulus = params.modulus;
+        let borrow_shift = 0x1000000000000000000000000000000;
+        let carry_shift = 0x1000000000000000000000000000000;
 
-    let mut subtrahend: [Field; N] = [0; N];
-    if (overflow_modulus) {
-        subtrahend = modulus;
-    }
-    let result_limb = lhs[0] + rhs[0] - subtrahend[0] - result[0]
-        + (borrow_flags[0] as Field * borrow_shift)
-        - (carry_flags[0] as Field * carry_shift);
-    assert(result_limb == 0);
-    for i in 1..N - 1 {
-        let result_limb = lhs[i] + rhs[i] - subtrahend[i] - result[i] - borrow_flags[i - 1] as Field
-            + carry_flags[i - 1] as Field
-            + ((borrow_flags[i] as Field - carry_flags[i] as Field) * borrow_shift);
+        let mut subtrahend: [Field; N] = [0; N];
+        if (overflow_modulus) {
+            subtrahend = modulus;
+        }
+        let result_limb = lhs[0] + rhs[0] - subtrahend[0] - result[0]
+            + (borrow_flags[0] as Field * borrow_shift)
+            - (carry_flags[0] as Field * carry_shift);
         assert(result_limb == 0);
+        for i in 1..N - 1 {
+            let result_limb = lhs[i] + rhs[i]
+                - subtrahend[i]
+                - result[i]
+                - borrow_flags[i - 1] as Field
+                + carry_flags[i - 1] as Field
+                + ((borrow_flags[i] as Field - carry_flags[i] as Field) * borrow_shift);
+            assert(result_limb == 0);
+        }
+        let result_limb = lhs[N - 1] + rhs[N - 1]
+            - subtrahend[N - 1]
+            - result[N - 1]
+            - borrow_flags[N - 2] as Field
+            + carry_flags[N - 2] as Field;
+        assert(result_limb == 0);
+        result
     }
-    let result_limb = lhs[N - 1] + rhs[N - 1]
-        - subtrahend[N - 1]
-        - result[N - 1]
-        - borrow_flags[N - 2] as Field
-        + carry_flags[N - 2] as Field;
-    assert(result_limb == 0);
-    result
 }
 
 pub(crate) fn sub<let N: u32, let MOD_BITS: u32>(
@@ -391,36 +413,43 @@ pub(crate) fn sub<let N: u32, let MOD_BITS: u32>(
     lhs: [Field; N],
     rhs: [Field; N],
 ) -> [Field; N] {
-    // so we do... p - x - r = 0 and there might be borrow flags
-    // a - b = r
-    // p + a - b - r = 0
-    let (result, carry_flags, borrow_flags, underflow) =
-        unsafe { __sub_with_flags(params, lhs, rhs) };
-    validate_in_range::<_, MOD_BITS>(result);
-    let modulus = params.modulus;
-    let borrow_shift = 0x1000000000000000000000000000000;
-    let carry_shift = 0x1000000000000000000000000000000;
+    if std::runtime::is_unconstrained() {
+        // Safety: not need to constrain in unconstrained runtime
+        unsafe {
+            __sub(params, lhs, rhs)
+        }
+    } else {
+        // so we do... p - x - r = 0 and there might be borrow flags
+        // a - b = r
+        // p + a - b - r = 0
+        let (result, carry_flags, borrow_flags, underflow) =
+            unsafe { __sub_with_flags(params, lhs, rhs) };
+        validate_in_range::<_, MOD_BITS>(result);
+        let modulus = params.modulus;
+        let borrow_shift = 0x1000000000000000000000000000000;
+        let carry_shift = 0x1000000000000000000000000000000;
 
-    let mut addend: [Field; N] = [0; N];
-    if (underflow) {
-        addend = modulus;
-    }
-    let result_limb = lhs[0] - rhs[0] + addend[0] - result[0]
-        + (borrow_flags[0] as Field * borrow_shift)
-        - (carry_flags[0] as Field * carry_shift);
-    assert(result_limb == 0);
-    for i in 1..N - 1 {
-        let result_limb = lhs[i] - rhs[i] + addend[i] - result[i] - borrow_flags[i - 1] as Field
-            + carry_flags[i - 1] as Field
-            + ((borrow_flags[i] as Field - carry_flags[i] as Field) * borrow_shift);
+        let mut addend: [Field; N] = [0; N];
+        if (underflow) {
+            addend = modulus;
+        }
+        let result_limb = lhs[0] - rhs[0] + addend[0] - result[0]
+            + (borrow_flags[0] as Field * borrow_shift)
+            - (carry_flags[0] as Field * carry_shift);
         assert(result_limb == 0);
+        for i in 1..N - 1 {
+            let result_limb = lhs[i] - rhs[i] + addend[i] - result[i] - borrow_flags[i - 1] as Field
+                + carry_flags[i - 1] as Field
+                + ((borrow_flags[i] as Field - carry_flags[i] as Field) * borrow_shift);
+            assert(result_limb == 0);
+        }
+        let result_limb = lhs[N - 1] - rhs[N - 1] + addend[N - 1]
+            - result[N - 1]
+            - borrow_flags[N - 2] as Field
+            + carry_flags[N - 2] as Field;
+        assert(result_limb == 0);
+        result
     }
-    let result_limb = lhs[N - 1] - rhs[N - 1] + addend[N - 1]
-        - result[N - 1]
-        - borrow_flags[N - 2] as Field
-        + carry_flags[N - 2] as Field;
-    assert(result_limb == 0);
-    result
 }
 
 // Note: this method is expensive! Try to craft quadratic relations and directly evaluate them

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -498,10 +498,10 @@ pub(crate) fn udiv_mod<let N: u32, let MOD_BITS: u32>(
             [numerator, remainder],
             [true, false],
         );
+        // we need (remainder < divisor)
+        // implies (divisor - remainder > 0)
+        validate_gt::<_, MOD_BITS>(divisor, remainder);
     }
-    // we need (remainder < divisor)
-    // implies (divisor - remainder > 0)
-    validate_gt::<_, MOD_BITS>(divisor, remainder);
     (quotient, remainder)
 }
 

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -432,7 +432,6 @@ pub(crate) fn mul<let N: u32, let MOD_BITS: u32>(
     lhs: [Field; N],
     rhs: [Field; N],
 ) -> [Field; N] {
-    /// Safety: `result` is checked by `evaluate_quadratic_expression`
     let result = unsafe { __mul::<_, MOD_BITS>(params, lhs, rhs) };
     if !std::runtime::is_unconstrained() {
         evaluate_quadratic_expression(
@@ -458,7 +457,6 @@ pub(crate) fn div<let N: u32, let MOD_BITS: u32>(
         params.has_multiplicative_inverse,
         "BigNum has no multiplicative inverse. Use udiv for unsigned integer division",
     );
-    /// Safety: `result` is checked by `evaluate_quadratic_expression`
     let result = unsafe { __div::<_, MOD_BITS>(params, lhs, rhs) };
     if !std::runtime::is_unconstrained() {
         evaluate_quadratic_expression(
@@ -486,7 +484,6 @@ pub(crate) fn udiv_mod<let N: u32, let MOD_BITS: u32>(
     numerator: [Field; N],
     divisor: [Field; N],
 ) -> ([Field; N], [Field; N]) {
-    /// Safety: `quotient` and `remainder` are checked by `evaluate_quadratic_expression`
     let (quotient, remainder) = unsafe { __udiv_mod(numerator, divisor) };
 
     if !std::runtime::is_unconstrained() {


### PR DESCRIPTION
# Description


## Problem\*

Resolves #91 

## Summary\*

Constrain ops via `evaluate_quadratic_expression` only in constrained context.

## Additional Context

@TomAFrench should`validate_gt::<_, MOD_BITS>(divisor, remainder);` from `fn udiv_mod` also be inside `if !std::runtime::is_unconstrained()`?

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
