### PR TITLE
feat: remove unnecessary usage of slices

### DIFF
--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -169,27 +169,27 @@ where
 
     unconstrained fn __neg(self) -> Self {
         let params = Params::get_params();
-        Self::from_slice(__neg(params, self.limbs))
+        Self { limbs: __neg(params, self.limbs)}
     }
 
     unconstrained fn __add(self, other: Self) -> Self {
         let params = Params::get_params();
-        Self::from_slice(__add(params, self.limbs, other.limbs))
+        Self { limbs: __add(params, self.limbs, other.limbs)}
     }
 
     unconstrained fn __sub(self, other: Self) -> Self {
         let params = Params::get_params();
-        Self::from_slice(__sub(params, self.limbs, other.limbs))
+        Self { limbs: __sub(params, self.limbs, other.limbs)}
     }
 
     unconstrained fn __mul(self, other: Self) -> Self {
         let params = Params::get_params();
-        Self::from_slice(__mul::<_, MOD_BITS>(params, self.limbs, other.limbs))
+        Self { limbs: __mul::<_, MOD_BITS>(params, self.limbs, other.limbs)}
     }
 
     unconstrained fn __div(self, divisor: Self) -> Self {
         let params = Params::get_params();
-        Self::from_slice(__div::<_, MOD_BITS>(params, self.limbs, divisor.limbs))
+        Self { limbs: __div::<_, MOD_BITS>(params, self.limbs, divisor.limbs) }
     }
 
     unconstrained fn __udiv_mod(self, divisor: Self) -> (Self, Self) {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

These calls are hiding an unnecessary conversion from arrays to slices and back to arrays. Instead we can now just move the array into the bignum.

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
