### PR TITLE
chore: remove unnecessary default implementation of `Eq`

### DIFF
--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -74,9 +74,6 @@ pub trait BigNumTrait: Neg + Add + Sub + Mul + Div + Eq {
         add_flags: [bool; ADD_N],
     );
 
-    pub fn eq(self, other: Self) -> bool {
-        self == other
-    }
     pub fn assert_is_not_equal(self, other: Self);
     pub fn validate_in_range(self);
     pub fn validate_in_field(self);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is implied by the trait constraint so we don't need to declare it again on the trait.

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
