### PR TITLE
Fix Typographical Errors in Comments

### DIFF
--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -131,7 +131,7 @@ pub(crate) fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32
 
     // we want to convert our byte array into bigfield chunks
     // each chunk has at most N-1 limbs
-    // to determine the exact number of chunks, we need the `!=` or `>` operator which is not avaiable when defining array sizes
+    // to determine the exact number of chunks, we need the `!=` or `>` operator which is not available when defining array sizes
     // so we overestimate at 4
     // e.g. if N = 20, then we have 40 limbs we want to reduce, but each bigfield chunk is 19 limbs, so we need 3
     // if N = 2, we have 4 limbs we want to reduce but each bigfield chunk is only 1 limb, so we need 4

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -1,4 +1,4 @@
-/// Multiple entires in the `MUL_DE_BRUIJN_BIT` list do not map to a valid output of `v * 0x6c04f118e9966f6b`.
+/// Multiple entries in the `MUL_DE_BRUIJN_BIT` list do not map to a valid output of `v * 0x6c04f118e9966f6b`.
 /// This is a dummy value to fill the gaps in the map.
 global n1: u32 = 0xffffffff;
 


### PR DESCRIPTION
# Fix Typographical Errors in Comments

## Description

This pull request addresses two typographical errors in comment sections across two files. The changes improve the readability and accuracy of the documentation.

### Summary of Changes

#### **File:** `src/fns/constrained_ops.nr`
- **Typo:** "avaiable" corrected to "available."
  - **Original:** `operator which is not avaiable when defining array sizes`
  - **Corrected:** `operator which is not available when defining array sizes`

#### **File:** `src/utils/msb.nr`
- **Typo:** "entires" corrected to "entries."
  - **Original:** `Multiple entires in the MUL_DE_BRUIJN_BIT list`
  - **Corrected:** `Multiple entries in the MUL_DE_BRUIJN_BIT list`

### Why These Fixes Are Important

- Ensures comments are clear and free from distracting typographical errors.
- Aligns with codebase standards for professionalism and readability.
- Assists contributors and maintainers in understanding code without confusion.

## Checklist

- [x] Corrected typos as described.
- [x] Verified no unintended changes were made.
- [x] Followed [contributing guidelines](https://github.com/noir-lang/noir-bignum/blob/main/CONTRIBUTING.md).

---

### Notes for Reviewers

These changes are minor and do not affect the functionality of the code. Please let me know if further revisions or improvements are needed. Thank you for your time and attention!
