### PR TITLE
chore: remove unused generic

### DIFF
--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -358,10 +358,7 @@ pub(crate) unconstrained fn __tonelli_shanks_sqrt<let N: u32, let MOD_BITS: u32>
     result
 }
 
-pub(crate) unconstrained fn __gte<let N: u32, let MOD_BITS: u32>(
-    lhs: [u128; N],
-    rhs: [u128; N],
-) -> bool {
+pub(crate) unconstrained fn __gte<let N: u32>(lhs: [u128; N], rhs: [u128; N]) -> bool {
     let mut result = false;
     let mut early_exit = false;
     for i in 0..(N) {


### PR DESCRIPTION
# Description

## Problem

There's an unused generic.

## Summary

Right now this doesn't trigger an error but [soon it will](https://github.com/noir-lang/noir/pull/7843).

## Additional Context


# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
