### PR TITLE
fix: fixed the array length bug when normalizing limbs in multiplication 

### DIFF
--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -200,7 +200,7 @@ pub(crate) unconstrained fn __barrett_reduction<let N: u32>(
         }
     }
 
-    let mulout: [u128; 3 * N] = __normalize_limbs(mulout_field, 3 * N - 1);
+    let mulout: [u128; 3 * N] = __normalize_limbs(mulout_field, 3 * N);
 
     // When we apply the barrett reduction, the maximum value of the output will be
     // <= p * (1 + x/2^{2k})

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -111,7 +111,6 @@ pub(crate) unconstrained fn __mul_with_quotient<let N: u32, let MOD_BITS: u32>(
     }
     let to_reduce: [u128; (N * 2)] = split_bits::__normalize_limbs(mul, 2 * N);
     let (q, r) = __barrett_reduction(to_reduce, params.redc_param, MOD_BITS, params.modulus);
-    // ([0; N], [0; N])
     (q, r)
 }
 

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -974,3 +974,29 @@ fn test_cmp_BN_fuzz(seed: [u8; 5]) {
     a = if a > modulus_sub_1_div_2 { -a } else { a };
     assert(a < modulus_sub_1_div_2);
 }
+
+struct SecP224r1_Params {}
+type SecP224r1 = BigNum<2, 224, SecP224r1_Params>;
+
+impl BigNumParamsGetter<2, 224> for SecP224r1_Params {
+    fn get_params() -> BigNumParams<2, 224> {
+        SecP224r1_PARAMS
+    }
+}
+global SecP224r1_PARAMS: BigNumParams<2, 224> = BigNumParams {
+    has_multiplicative_inverse: true,
+    modulus: [0xffffff000000000000000000000001, 0xffffffffffffffffffffffffff],
+    double_modulus: [0x01fffffe000000000000000000000002, 0x01fffffffffffffffffffffffffe],
+    redc_param: [0x0ffffffffffffffffffffffff0, 0x1000000000000000000000000000],
+};
+
+#[test]
+fn test_SecP224r1_mul_regression() {
+    let mut x: SecP224r1 =
+        SecP224r1 { limbs: [0x03c1d356c21122343280d6115c1d21, 0xb70e0cbd6bb4bf7f321390b94a] };
+    let res = x * x;
+    let expected = unsafe { SecP224r1::__mul(x, x) };
+    res.validate_in_field();
+    expected.validate_in_field();
+    assert(res == expected);
+}

--- a/src/utils/split_bits.nr
+++ b/src/utils/split_bits.nr
@@ -21,6 +21,7 @@ pub(crate) unconstrained fn __normalize_limbs<let N: u32>(
     }
     {
         let (lo, hi) = split_120_bits(next);
+
         normalized[range - 1] = lo as u128;
         assert(hi == 0);
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->
#152 
## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
