### PR TITLE
fix: replace references to associated constants with macro-generated constants

### DIFF
--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -7,12 +7,8 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     let MOD_BITS: u32;
 
     fn params() -> BigNumParams<N, MOD_BITS>;
-    fn modulus_bits(_: Self) -> u32 {
-        BigNum::MOD_BITS
-    }
-    fn num_limbs(_: Self) -> u32 {
-        BigNum::N
-    }
+    fn modulus_bits(_: Self) -> u32;
+    fn num_limbs(_: Self) -> u32;
     fn modulus() -> Self;
 
     fn new() -> Self;
@@ -88,6 +84,14 @@ pub(crate) comptime fn derive_bignum_impl(
             let N: u32 = $N; 
             let MOD_BITS: u32 = $MOD_BITS;
             
+            fn modulus_bits(_: Self) -> u32 {
+                $MOD_BITS
+            }
+            
+            fn num_limbs(_: Self) -> u32 {
+                $N
+            }
+
             fn modulus() -> Self {
                 Self { limbs: Self::params().modulus }
             }

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -282,7 +282,6 @@ fn test_num_limbs_BN() {
     assert_eq(BN254_Fq::zero().num_limbs(), 3)
 }
 
-
 #[test]
 fn test_eq_BN() {
     test_eq::<3, BN254_Fq>();

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -273,6 +273,17 @@ where
 }
 
 #[test]
+fn test_modulus_bits_BN() {
+    assert_eq(BN254_Fq::zero().modulus_bits(), 254)
+}
+
+#[test]
+fn test_num_limbs_BN() {
+    assert_eq(BN254_Fq::zero().num_limbs(), 3)
+}
+
+
+#[test]
 fn test_eq_BN() {
     test_eq::<3, BN254_Fq>();
 }


### PR DESCRIPTION
…constants

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This works around https://github.com/noir-lang/noir/issues/8096 by injecting a constant equal to the associated constant rather than trying to read it off of the trait.

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
