### PR TITLE
chore: avoid passing `params` object around unnecessarily

### DIFF
--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -161,7 +161,7 @@ pub(crate) comptime fn derive_bignum_impl(
 
             unconstrained fn __add(self: Self, other: Self) -> Self {
                 let params = Self::params();
-                Self {limbs: $unconstrained_ops::__add(params, self.get_limbs(), other.get_limbs())}
+                Self {limbs: $unconstrained_ops::__add(params.modulus, self.get_limbs(), other.get_limbs())}
             }
 
             unconstrained fn __sub(self: Self, other: Self) -> Self {

--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -156,7 +156,7 @@ pub(crate) comptime fn derive_bignum_impl(
 
             unconstrained fn __neg(self: Self) -> Self {
                 let params = Self::params();
-                Self {limbs: $unconstrained_ops::__neg(params, self.get_limbs())}
+                Self {limbs: $unconstrained_ops::__neg(params.modulus, self.get_limbs())}
             }
 
             unconstrained fn __add(self: Self, other: Self) -> Self {

--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -166,7 +166,7 @@ pub(crate) comptime fn derive_bignum_impl(
 
             unconstrained fn __sub(self: Self, other: Self) -> Self {
                 let params = Self::params();
-                Self {limbs: $unconstrained_ops::__sub(params, self.get_limbs(), other.get_limbs())}
+                Self {limbs: $unconstrained_ops::__sub(params.modulus, self.get_limbs(), other.get_limbs())}
             }
 
             unconstrained fn __mul(self: Self, other: Self) -> Self {

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -357,7 +357,7 @@ pub(crate) fn neg<let N: u32, let MOD_BITS: u32>(
     if std::runtime::is_unconstrained() {
         // Safety: not need to constrain in unconstrained runtime
         unsafe {
-            __neg(params, val)
+            __neg(params.modulus, val)
         }
     } else {
         // so we do... p - x - r = 0 and there might be borrow flags

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -435,7 +435,7 @@ pub(crate) fn sub<let N: u32, let MOD_BITS: u32>(
     if std::runtime::is_unconstrained() {
         // Safety: not need to constrain in unconstrained runtime
         unsafe {
-            __sub(params, lhs, rhs)
+            __sub(params.modulus, lhs, rhs)
         }
     } else {
         // so we do... p - x - r = 0 and there might be borrow flags

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -442,7 +442,7 @@ pub(crate) fn sub<let N: u32, let MOD_BITS: u32>(
         // a - b = r
         // p + a - b - r = 0
         let (result, carry_flags, borrow_flags, underflow) =
-            unsafe { __sub_with_flags(params, lhs, rhs) };
+            unsafe { __sub_with_flags(params.modulus, lhs, rhs) };
 
         validate_in_range::<_, _, MOD_BITS>(result);
         let modulus = params.modulus;

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -393,7 +393,7 @@ pub(crate) fn add<let N: u32, let MOD_BITS: u32>(
     } else {
         // so we do... p - x - r = 0 and there might be borrow flags
         let (result, carry_flags, borrow_flags, overflow_modulus) =
-            unsafe { __add_with_flags(params, lhs, rhs) };
+            unsafe { __add_with_flags(params.modulus, lhs, rhs) };
         validate_in_range::<_, _, MOD_BITS>(result);
         let modulus = params.modulus;
 

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -361,7 +361,7 @@ pub(crate) fn neg<let N: u32, let MOD_BITS: u32>(
         }
     } else {
         // so we do... p - x - r = 0 and there might be borrow flags
-        let (result, borrow_flags) = unsafe { __neg_with_flags(params, val) };
+        let (result, borrow_flags) = unsafe { __neg_with_flags(params.modulus, val) };
         validate_in_range::<_, _, MOD_BITS>(result);
         let modulus = params.modulus;
         let result_limb = modulus[0] + (borrow_flags[0] as u128 * TWO_POW_120) - val[0] - result[0];

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -388,7 +388,7 @@ pub(crate) fn add<let N: u32, let MOD_BITS: u32>(
         // Safety: not need to constrain in unconstrained runtime
         unsafe {
             // __add_u128(params, lhs, rhs)
-            __add(params, lhs, rhs)
+            __add(params.modulus, lhs, rhs)
         }
     } else {
         // so we do... p - x - r = 0 and there might be borrow flags

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -302,7 +302,7 @@ unconstrained fn __recursively_find_multiplicative_generator<let N: u32, let MOD
 ) -> (bool, [u128; N]) {
     let exped = __pow(params, target, p_minus_one_over_two);
     let one: [u128; N] = __one();
-    let neg_one = __neg(params, one);
+    let neg_one = __neg(params.modulus, one);
     let found = exped == neg_one;
     let mut result: (bool, [u128; N]) = (found, target);
     if (!found) {

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -143,15 +143,15 @@ pub(crate) unconstrained fn __add_with_flags<let N: u32>(
     (result, carry_flags, borrow_flags, overflow)
 }
 
-pub(crate) unconstrained fn __sub_with_flags<let N: u32, let MOD_BITS: u32>(
-    params: P<N, MOD_BITS>,
+pub(crate) unconstrained fn __sub_with_flags<let N: u32>(
+    modulus: [u128; N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> ([u128; N], [bool; N], [bool; N - 1], bool) {
     let mut one: [u128; N] = [0; N];
     one[0] = 1;
     let underflow = !__gte(lhs, rhs);
-    let addend: [u128; N] = if underflow { params.modulus } else { [0; N] };
+    let addend: [u128; N] = if underflow { modulus } else { [0; N] };
     let mut result: [u128; N] = [0; N];
 
     let mut carry_in: u128 = 0;

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -101,7 +101,7 @@ pub(crate) unconstrained fn __neg_with_flags<let N: u32, let MOD_BITS: u32>(
     (result, borrow_flags)
 }
 
-pub(crate) unconstrained fn __add_with_flags<let N: u32, let MOD_BITS: u32>(
+pub(crate) unconstrained fn __add_with_flags<let N: u32>(
     modulus: [u128;N],
     lhs: [u128; N],
     rhs: [u128; N],

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -80,8 +80,8 @@ pub(crate) unconstrained fn __validate_gt_remainder<let N: u32>(
     (underflow, result, carry_flags, borrow_flags)
 }
 
-pub(crate) unconstrained fn __neg_with_flags<let N: u32, let MOD_BITS: u32>(
-    params: P<N, MOD_BITS>,
+pub(crate) unconstrained fn __neg_with_flags<let N: u32>(
+    modulus: [u128; N],
     val: [u128; N],
 ) -> ([u128; N], [bool; N - 1]) {
     let mut result: [u128; N] = [0; N];
@@ -90,8 +90,8 @@ pub(crate) unconstrained fn __neg_with_flags<let N: u32, let MOD_BITS: u32>(
     let mut borrow_flags: [bool; N - 1] = [false; N - 1];
     for i in 0..N {
         let sub_term = val[i] + borrow_in;
-        let borrow = (sub_term > params.modulus[i]) as u128;
-        result[i] = borrow * TWO_POW_120 + params.modulus[i] - sub_term;
+        let borrow = (sub_term > modulus[i]) as u128;
+        result[i] = borrow * TWO_POW_120 + modulus[i] - sub_term;
 
         borrow_in = borrow;
         if (i < N - 1) {
@@ -102,7 +102,7 @@ pub(crate) unconstrained fn __neg_with_flags<let N: u32, let MOD_BITS: u32>(
 }
 
 pub(crate) unconstrained fn __add_with_flags<let N: u32>(
-    modulus: [u128;N],
+    modulus: [u128; N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> ([u128; N], [bool; N], [bool; N - 1], bool) {

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -102,18 +102,18 @@ pub(crate) unconstrained fn __neg_with_flags<let N: u32, let MOD_BITS: u32>(
 }
 
 pub(crate) unconstrained fn __add_with_flags<let N: u32, let MOD_BITS: u32>(
-    params: P<N, MOD_BITS>,
+    modulus: [u128;N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> ([u128; N], [bool; N], [bool; N - 1], bool) {
     let add_res = __helper_add(lhs, rhs);
-    let overflow = __gte(add_res, params.modulus);
+    let overflow = __gte(add_res, modulus);
 
     let mut subtrahend: [u128; N] = [0; N];
     let mut result: [u128; N] = [0; N];
 
     if overflow {
-        subtrahend = params.modulus;
+        subtrahend = modulus;
     }
 
     let mut carry_in: u128 = 0;

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -306,7 +306,7 @@ unconstrained fn __recursively_find_multiplicative_generator<let N: u32, let MOD
     let found = exped == neg_one;
     let mut result: (bool, [u128; N]) = (found, target);
     if (!found) {
-        let _target: [u128; N] = __add(params, target, one);
+        let _target: [u128; N] = __add(params.modulus, target, one);
         result = __recursively_find_multiplicative_generator::<_, MOD_BITS>(
             params,
             _target,

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -57,12 +57,11 @@ pub(crate) unconstrained fn __is_zero<let N: u32>(limbs: [u128; N]) -> bool {
 *              N.B. constrained BigNum operations do not fully constrain outputs to be in the range [0, p-1]
 *              because such a check is expensive and usually unneccesary.
 */
-pub(crate) unconstrained fn __neg<let N: u32, let MOD_BITS: u32>(
-    params: P<N, MOD_BITS>,
+pub(crate) unconstrained fn __neg<let N: u32>(
+    modulus: [u128;N],
     limbs: [u128; N],
 ) -> [u128; N] {
-    let f: [u128; N] = limbs;
-    __helper_sub(params.modulus, f)
+    __helper_sub(modulus, limbs)
 }
 
 pub(crate) unconstrained fn __add<let N: u32, let MOD_BITS: u32>(
@@ -95,7 +94,7 @@ pub(crate) unconstrained fn __sub<let N: u32, let MOD_BITS: u32>(
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> [u128; N] {
-    __add(params, lhs, __neg(params, rhs))
+    __add(params, lhs, __neg(params.modulus, rhs))
 }
 
 pub(crate) unconstrained fn __mul_with_quotient<let N: u32, let MOD_BITS: u32>(

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -64,8 +64,8 @@ pub(crate) unconstrained fn __neg<let N: u32>(
     __helper_sub(modulus, limbs)
 }
 
-pub(crate) unconstrained fn __add<let N: u32, let MOD_BITS: u32>(
-    params: P<N, MOD_BITS>,
+pub(crate) unconstrained fn __add<let N: u32>(
+    modulus: [u128;N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> [u128; N] {
@@ -78,8 +78,8 @@ pub(crate) unconstrained fn __add<let N: u32, let MOD_BITS: u32>(
         result[i] = add_term;
     }
     // check if the result is greater than the modulus
-    if __gte(result, params.modulus) {
-        __helper_sub(result, params.modulus)
+    if __gte(result, modulus) {
+        __helper_sub(result, modulus)
     } else {
         result
     }
@@ -94,7 +94,7 @@ pub(crate) unconstrained fn __sub<let N: u32, let MOD_BITS: u32>(
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> [u128; N] {
-    __add(params, lhs, __neg(params.modulus, rhs))
+    __add(params.modulus, lhs, __neg(params.modulus, rhs))
 }
 
 pub(crate) unconstrained fn __mul_with_quotient<let N: u32, let MOD_BITS: u32>(

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -57,15 +57,12 @@ pub(crate) unconstrained fn __is_zero<let N: u32>(limbs: [u128; N]) -> bool {
 *              N.B. constrained BigNum operations do not fully constrain outputs to be in the range [0, p-1]
 *              because such a check is expensive and usually unneccesary.
 */
-pub(crate) unconstrained fn __neg<let N: u32>(
-    modulus: [u128;N],
-    limbs: [u128; N],
-) -> [u128; N] {
+pub(crate) unconstrained fn __neg<let N: u32>(modulus: [u128; N], limbs: [u128; N]) -> [u128; N] {
     __helper_sub(modulus, limbs)
 }
 
 pub(crate) unconstrained fn __add<let N: u32>(
-    modulus: [u128;N],
+    modulus: [u128; N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> [u128; N] {
@@ -90,7 +87,7 @@ pub(crate) unconstrained fn __add<let N: u32>(
 * @description see `__neg` for why we use 2p instead of p
 **/
 pub(crate) unconstrained fn __sub<let N: u32, let MOD_BITS: u32>(
-   modulus: [u128;N],
+    modulus: [u128; N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> [u128; N] {

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -90,11 +90,11 @@ pub(crate) unconstrained fn __add<let N: u32>(
 * @description see `__neg` for why we use 2p instead of p
 **/
 pub(crate) unconstrained fn __sub<let N: u32, let MOD_BITS: u32>(
-    params: P<N, MOD_BITS>,
+   modulus: [u128;N],
     lhs: [u128; N],
     rhs: [u128; N],
 ) -> [u128; N] {
-    __add(params.modulus, lhs, __neg(params.modulus, rhs))
+    __add(modulus, lhs, __neg(modulus, rhs))
 }
 
 pub(crate) unconstrained fn __mul_with_quotient<let N: u32, let MOD_BITS: u32>(

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -132,7 +132,7 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
     pub fn __sub(self, other: Self) -> Self {
         let params = self.params;
         assert(params == other.params);
-        let limbs = unsafe { __sub(params, self.limbs, other.limbs) };
+        let limbs = unsafe { __sub(params.modulus, self.limbs, other.limbs) };
         Self { params, limbs }
     }
 

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -124,7 +124,7 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
     pub fn __add(self, other: Self) -> Self {
         let params = self.params;
         assert(params == other.params);
-        let limbs = unsafe { __add(params, self.limbs, other.limbs) };
+        let limbs = unsafe { __add(params.modulus, self.limbs, other.limbs) };
         Self { params, limbs }
     }
 

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -116,7 +116,7 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
     // UNCONSTRAINED! (Hence `__` prefix).
     pub fn __neg(self) -> Self {
         let params = self.params;
-        let limbs = unsafe { __neg(params, self.limbs) };
+        let limbs = unsafe { __neg(params.modulus, self.limbs) };
         Self { params, limbs }
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
