### PR TITLE
fix: remove unused generic in trait impl

### DIFF
--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -278,7 +278,7 @@ impl<let N: u32, let MOD_BITS: u32> std::cmp::Eq for RuntimeBigNum<N, MOD_BITS> 
     }
 }
 
-impl<let N: u32, let MOD_BITS: u32, Params> std::cmp::Ord for RuntimeBigNum<N, MOD_BITS> {
+impl<let N: u32, let MOD_BITS: u32> std::cmp::Ord for RuntimeBigNum<N, MOD_BITS> {
     fn cmp(self, other: Self) -> Ordering {
         assert(self.params == other.params);
         cmp::<_, MOD_BITS>(self.limbs, other.limbs)


### PR DESCRIPTION
# Description

## Problem

A requirement for https://github.com/noir-lang/noir/pull/8395

## Summary



## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
