### PR TITLE
fix: bump poseidon to v0.1.1

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.0" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }


### PR DESCRIPTION
# Description

## Problem

Towards https://github.com/noir-lang/noir/pull/7908

## Summary



## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
