### PR TITLE
fix: remove `as_array` call for which `N` cannot be deduced

### DIFF
--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -344,7 +344,6 @@ pub fn __batch_invert<let N: u32, let MOD_BITS: u32, let M: u32>(
     all_limbs.map(|limbs| RuntimeBigNum { limbs, params })
 }
 
-// Note: can't return a slice from this unconstrained to a constrained function.
 pub unconstrained fn __batch_invert_slice<let N: u32, let MOD_BITS: u32, let M: u32>(
     x: [RuntimeBigNum<N, MOD_BITS>],
 ) -> [RuntimeBigNum<N, MOD_BITS>] {

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -355,7 +355,7 @@ pub unconstrained fn __batch_invert_slice<let N: u32, let MOD_BITS: u32, let M: 
         x.map(|bn| RuntimeBigNum::get_limbs(bn)),
     );
 
-    all_limbs.map(|limbs| RuntimeBigNum { limbs, params }).as_array()
+    all_limbs.map(|limbs| RuntimeBigNum { limbs, params })
 }
 
 pub fn conditional_select<let N: u32, let MOD_BITS: u32>(


### PR DESCRIPTION
# Description

## Problem

Towards https://github.com/noir-lang/noir/pull/8686

## Summary

I'm not sure how this compiled before https://github.com/noir-lang/noir/pull/8686: the `as_array` call converted the slice to an array, then I think with implicit rules it was converted back to a slice. But... what's the size of that intermediate array? It can't be deduced. Removing the `as_array` call fixes this, as I think it was never needed (and I think the comment on top of the function saying we can't return slice might be outdated).

## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
