### PR TITLE
fix: Refactor __get_msb to work on a single 128bit debrujin sequence

### DIFF
--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -1,7 +1,7 @@
 use crate::constants::{TWO_POW_119, TWO_POW_120};
 use crate::fns::unconstrained_ops::{__add, __gte, __mul, __neg, __one, __pow};
 use crate::params::BigNumParams as P;
-use crate::utils::msb::get_msb128;
+use crate::utils::msb::get_msb;
 use crate::utils::split_bits::__normalize_limbs;
 
 pub(crate) unconstrained fn __from_field<let N: u32>(field: Field) -> [u128; N] {
@@ -451,7 +451,7 @@ pub(crate) unconstrained fn __get_msb<let N: u32>(val: [u128; N]) -> u32 {
     for i in 0..N {
         let v = val[(N - 1 - i)];
         if (v > 0) {
-            count = 120 * (N - 1 - i) + get_msb128(v);
+            count = 120 * (N - 1 - i) + get_msb(v);
             break;
         }
     }

--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -1,7 +1,7 @@
-use crate::constants::{TWO_POW_119, TWO_POW_120, TWO_POW_60};
+use crate::constants::{TWO_POW_119, TWO_POW_120};
 use crate::fns::unconstrained_ops::{__add, __gte, __mul, __neg, __one, __pow};
 use crate::params::BigNumParams as P;
-use crate::utils::msb::get_msb64;
+use crate::utils::msb::get_msb128;
 use crate::utils::split_bits::__normalize_limbs;
 
 pub(crate) unconstrained fn __from_field<let N: u32>(field: Field) -> [u128; N] {
@@ -449,15 +449,9 @@ pub(crate) unconstrained fn __shr1<let N: u32>(mut input: [u128; N]) -> [u128; N
 pub(crate) unconstrained fn __get_msb<let N: u32>(val: [u128; N]) -> u32 {
     let mut count = 0;
     for i in 0..N {
-        let v = val[((N) - 1 - i)];
-        let v_low = v as u64 % TWO_POW_60 as u64;
-        let v_high = ((v - v_low as u128) / TWO_POW_60) as u64;
-        if (v_high > 0) {
-            count = 60 * ((2 * N) - 1 - (i * 2)) + get_msb64(v_high);
-            break;
-        }
-        if (v_low > 0) {
-            count = 60 * ((2 * N) - 1 - (i * 2 + 1)) + get_msb64(v_low);
+        let v = val[(N - 1 - i)];
+        if (v > 0) {
+            count = 120 * (N - 1 - i) + get_msb128(v);
             break;
         }
     }

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -1,4 +1,4 @@
-global MUL_DE_BRUIJN_BIT_128: [u32; 128] = [
+global MUL_DE_BRUIJN_BIT: [u32; 128] = [
     1, 14, 2, 15, 26, 20, 3, 16, 68, 80, 27, 21, 56, 50, 4, 17, 65, 96, 69, 81, 105, 99, 28, 22, 86,
     90, 57, 51, 72, 42, 5, 126, 18, 66, 48, 94, 97, 84, 70, 124, 82, 122, 106, 100, 114, 108, 29,
     23, 77, 102, 87, 91, 119, 116, 58, 52, 61, 110, 73, 37, 43, 31, 6, 127, 13, 25, 19, 67, 79, 55,
@@ -7,7 +7,7 @@ global MUL_DE_BRUIJN_BIT_128: [u32; 128] = [
     45, 111, 74, 34, 10, 38, 44, 33, 9, 32, 8, 7, 128,
 ];
 
-pub(crate) unconstrained fn get_msb128(x: u128) -> u32 {
+pub(crate) unconstrained fn get_msb(x: u128) -> u32 {
     let result = if x == 0 {
         0
     } else {
@@ -21,7 +21,7 @@ pub(crate) unconstrained fn get_msb128(x: u128) -> u32 {
         v |= v >> 64;
         let index = (std::wrapping_mul(v, 0x1FC10C2FBCF471B913B14CD2595D6D5)) >> 121;
         (index as Field).assert_max_bit_size::<32>();
-        MUL_DE_BRUIJN_BIT_128[index as u32]
+        MUL_DE_BRUIJN_BIT[index as u32]
     };
     result
 }
@@ -29,7 +29,7 @@ pub(crate) unconstrained fn get_msb128(x: u128) -> u32 {
 mod tests {
     use crate::constants::{TWO_POW_120, TWO_POW_60};
     use crate::fns::unconstrained_helpers::__get_msb;
-    use super::get_msb128;
+    use super::get_msb as get_msb128;
 
     fn assert_msb_equal(x: u64) {
         let msb64 = unsafe { get_msb64(x) };

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -1,8 +1,11 @@
+use crate::constants::TWO_POW_60;
+use crate::fns::unconstrained_helpers::__get_msb;
+
 /// Multiple entires in the `MUL_DE_BRUIJN_BIT` list do not map to a valid output of `v * 0x6c04f118e9966f6b`.
 /// This is a dummy value to fill the gaps in the map.
 global n1: u32 = 0xffffffff;
 
-global MUL_DE_BRUIJN_BIT: [u32; 128] = [
+global MUL_DE_BRUIJN_BIT_64: [u32; 128] = [
     0, // change to 1 if you want bitSize(0) = 1
     48, n1, n1, 31, n1, 15, 51, n1, 63, 5, n1, n1, n1, 19, n1, 23, 28, n1, n1, n1, 40, 36, 46, n1,
     13, n1, n1, n1, 34, n1, 58, n1, 60, 2, 43, 55, n1, n1, n1, 50, 62, 4, n1, 18, 27, n1, 39, 45,
@@ -12,7 +15,16 @@ global MUL_DE_BRUIJN_BIT: [u32; 128] = [
     3, 26, 38, 44, n1, 56,
 ];
 
-pub unconstrained fn get_msb64(x: u64) -> u32 {
+global MUL_DE_BRUIJN_BIT_128: [u32; 128] = [
+    1, 14, 2, 15, 26, 20, 3, 16, 68, 80, 27, 21, 56, 50, 4, 17, 65, 96, 69, 81, 105, 99, 28, 22, 86,
+    90, 57, 51, 72, 42, 5, 126, 18, 66, 48, 94, 97, 84, 70, 124, 82, 122, 106, 100, 114, 108, 29,
+    23, 77, 102, 87, 91, 119, 116, 58, 52, 61, 110, 73, 37, 43, 31, 6, 127, 13, 25, 19, 67, 79, 55,
+    49, 64, 95, 104, 98, 85, 89, 71, 41, 125, 47, 93, 83, 123, 121, 113, 107, 76, 101, 118, 115, 60,
+    109, 36, 30, 12, 24, 78, 54, 63, 103, 88, 40, 46, 92, 120, 112, 75, 117, 59, 35, 11, 53, 62, 39,
+    45, 111, 74, 34, 10, 38, 44, 33, 9, 32, 8, 7, 128,
+];
+
+pub(crate) unconstrained fn get_msb64(x: u64) -> u32 {
     let mut v = x;
     v |= v >> 1;
     v |= v >> 2;
@@ -22,7 +34,167 @@ pub unconstrained fn get_msb64(x: u64) -> u32 {
     v |= v >> 32;
     let index = (std::wrapping_mul(v, 0x6c04f118e9966f6b)) >> 57;
     (index as Field).assert_max_bit_size::<32>();
-    MUL_DE_BRUIJN_BIT[index as u32]
+    MUL_DE_BRUIJN_BIT_64[index as u32]
 }
 
-// 1100
+pub(crate) unconstrained fn get_msb128(x: u128) -> u32 {
+    let result = if x == 0 {
+        0
+    } else {
+        let mut v = x;
+        v |= v >> 1;
+        v |= v >> 2;
+        v |= v >> 4;
+        v |= v >> 8;
+        v |= v >> 16;
+        v |= v >> 32;
+        v |= v >> 64;
+        let index = (std::wrapping_mul(v, 0x1FC10C2FBCF471B913B14CD2595D6D5)) >> 121;
+        (index as Field).assert_max_bit_size::<32>();
+        MUL_DE_BRUIJN_BIT_128[index as u32]
+    };
+    result
+}
+
+pub fn assert_msb_equal(x: u64) {
+    let msb64 = unsafe { get_msb64(x) };
+    let msb128 = unsafe { get_msb128(x as u128) };
+    assert_eq(msb64, msb128);
+}
+
+#[test]
+// To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
+fn test_get_msb() {
+    // Test case 1: MSB at position 7
+    let x = 0x80; // binary: 10000000
+    assert_msb_equal(x);
+
+    // Test case 2: MSB at position 0
+    let x = 0x1; // binary: 00000001
+    assert_msb_equal(x);
+
+    // Test case 3: MSB at position 63
+    let x = 0x8000000000000000; // binary: 1000...0000 (63 zeros)
+    assert_msb_equal(x);
+
+    // Test case 4: Zero input
+    let x = 0x0;
+    assert_msb_equal(x);
+
+    // Test case 5: All bits set
+    let x = 0xFFFFFFFFFFFFFFFF;
+    assert_msb_equal(x);
+}
+
+pub(crate) unconstrained fn __get_msb64<let N: u32>(val: [u128; N]) -> u32 {
+    let mut count = 0;
+    for i in 0..N {
+        let v = val[((N) - 1 - i)];
+        let v_low = v as u64 % TWO_POW_60 as u64;
+        let v_high = ((v - v_low as u128) / TWO_POW_60) as u64;
+        if (v_high > 0) {
+            count = 60 * ((2 * N) - 1 - (i * 2)) + get_msb64(v_high);
+            break;
+        }
+        if (v_low > 0) {
+            count = 60 * ((2 * N) - 1 - (i * 2 + 1)) + get_msb64(v_low);
+            break;
+        }
+    }
+    count
+}
+
+#[test]
+// To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
+fn test_get_msb_equivalence() {
+    // Test single limb (64-bit number)
+    let x = 0x8000000000000000;
+    let arr = [0, 0, x as u128, 0];
+    let msb1 = unsafe { __get_msb64(arr) };
+    let msb2 = unsafe { __get_msb(arr) };
+    assert_eq(msb1, msb2);
+
+    // Test multiple limbs (120-bit number)
+    let x = 0x800000000000000000000000000000; // 120 bits number
+    let arr = [0, 0, x as u128, 0];
+    let msb1 = unsafe { __get_msb64(arr) };
+    let msb2 = unsafe { __get_msb(arr) };
+    assert_eq(msb1, msb2);
+
+    // Test zero
+    let arr = [0, 0, 0, 0];
+    let msb1 = unsafe { __get_msb64(arr) };
+    let msb2 = unsafe { __get_msb(arr) };
+    assert_eq(msb1, msb2);
+
+    // Test all bits set (120 bits)
+    let x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 120 bits
+    let arr = [0, x as u128, 0, 0];
+    let msb1 = unsafe { __get_msb64(arr) };
+    let msb2 = unsafe { __get_msb(arr) };
+    assert_eq(msb1, msb2);
+
+    // Test systematic bit positions
+    for i in 0..120 {
+        let x: u128 = 1;
+        let shifted = x << i;
+        let arr = [0, shifted, 0, 0];
+        let msb1 = unsafe { __get_msb64(arr) };
+        let msb2 = unsafe { __get_msb(arr) };
+        assert_eq(msb1, msb2);
+    }
+
+    // Test random-like patterns (multiple bits set)
+    let patterns = [
+        0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // alternating bits
+        0x555555555555555555555555555555, // alternating bits (opposite)
+        0x1234567890ABCDEF1234567890ABCD, // some pattern
+        0xFEDCBA0987654321FEDCBA09876543, // some pattern
+        0x800000000000000000000000000001, // highest and lowest bits
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE, // all bits except lowest
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFF, // all bits except highest
+    ];
+    for i in 0..patterns.len() {
+        let arr = [0, patterns[i] as u128, 0, 0];
+        let msb1 = unsafe { __get_msb64(arr) };
+        let msb2 = unsafe { __get_msb(arr) };
+        assert_eq(msb1, msb2);
+    }
+
+    // Test with MSB in different array positions (120 bits)
+    let x = 0x800000000000000000000000000000; // 120 bits
+    let arr1 = [x as u128, 0, 0, 0];
+    let arr2 = [0, x as u128, 0, 0];
+    let arr3 = [0, 0, x as u128, 0];
+    let arr4 = [0, 0, 0, x as u128];
+    let msb1_1 = unsafe { __get_msb64(arr1) };
+    let msb2_1 = unsafe { __get_msb(arr1) };
+    assert_eq(msb1_1, msb2_1);
+
+    let msb1_2 = unsafe { __get_msb64(arr2) };
+    let msb2_2 = unsafe { __get_msb(arr2) };
+    assert_eq(msb1_2, msb2_2);
+
+    let msb1_3 = unsafe { __get_msb64(arr3) };
+    let msb2_3 = unsafe { __get_msb(arr3) };
+    assert_eq(msb1_3, msb2_3);
+
+    let msb1_4 = unsafe { __get_msb64(arr4) };
+    let msb2_4 = unsafe { __get_msb(arr4) };
+    assert_eq(msb1_4, msb2_4);
+}
+
+/*
+#[test]
+unconstrained fn fuzz_get_msb(seed: [u128; 5]) {
+    let mut seed_copy = seed;
+    for i in 0..5 {
+        if (seed_copy[i] as u128) >= TWO_POW_120 {
+            seed_copy[i] = seed_copy[i] & (TWO_POW_120 - 1);
+        }
+    }
+    let msb1 = unsafe { __get_msb64(seed_copy) };
+    let msb2 = unsafe { __get_msb(seed_copy) };
+    assert_eq(msb1, msb2);
+}
+*/

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -190,9 +190,7 @@ mod tests {
     unconstrained fn fuzz_get_msb(seed: [u128; 5]) {
         let mut seed_copy = seed;
         for i in 0..5 {
-            if (seed_copy[i] as u128) >= TWO_POW_120 {
-                seed_copy[i] = seed_copy[i] & (TWO_POW_120 - 1);
-            }
+            seed_copy[i] = seed_copy[i] & (TWO_POW_120 - 1);
         }
         let msb1 = unsafe { __get_msb64(seed_copy) };
         let msb2 = unsafe { __get_msb(seed_copy) };

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -1,20 +1,3 @@
-use crate::constants::TWO_POW_60;
-use crate::fns::unconstrained_helpers::__get_msb;
-
-/// Multiple entires in the `MUL_DE_BRUIJN_BIT` list do not map to a valid output of `v * 0x6c04f118e9966f6b`.
-/// This is a dummy value to fill the gaps in the map.
-global n1: u32 = 0xffffffff;
-
-global MUL_DE_BRUIJN_BIT_64: [u32; 128] = [
-    0, // change to 1 if you want bitSize(0) = 1
-    48, n1, n1, 31, n1, 15, 51, n1, 63, 5, n1, n1, n1, 19, n1, 23, 28, n1, n1, n1, 40, 36, 46, n1,
-    13, n1, n1, n1, 34, n1, 58, n1, 60, 2, 43, 55, n1, n1, n1, 50, 62, 4, n1, 18, 27, n1, 39, 45,
-    n1, n1, 33, 57, n1, 1, 54, n1, 49, n1, 17, n1, n1, 32, n1, 53, n1, 16, n1, n1, 52, n1, n1, n1,
-    64, 6, 7, 8, n1, 9, n1, n1, n1, 20, 10, n1, n1, 24, n1, 29, n1, n1, 21, n1, 11, n1, n1, 41, n1,
-    25, 37, n1, 47, n1, 30, 14, n1, n1, n1, n1, 22, n1, n1, 35, 12, n1, n1, n1, 59, 42, n1, n1, 61,
-    3, 26, 38, 44, n1, 56,
-];
-
 global MUL_DE_BRUIJN_BIT_128: [u32; 128] = [
     1, 14, 2, 15, 26, 20, 3, 16, 68, 80, 27, 21, 56, 50, 4, 17, 65, 96, 69, 81, 105, 99, 28, 22, 86,
     90, 57, 51, 72, 42, 5, 126, 18, 66, 48, 94, 97, 84, 70, 124, 82, 122, 106, 100, 114, 108, 29,
@@ -23,19 +6,6 @@ global MUL_DE_BRUIJN_BIT_128: [u32; 128] = [
     109, 36, 30, 12, 24, 78, 54, 63, 103, 88, 40, 46, 92, 120, 112, 75, 117, 59, 35, 11, 53, 62, 39,
     45, 111, 74, 34, 10, 38, 44, 33, 9, 32, 8, 7, 128,
 ];
-
-pub(crate) unconstrained fn get_msb64(x: u64) -> u32 {
-    let mut v = x;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v |= v >> 32;
-    let index = (std::wrapping_mul(v, 0x6c04f118e9966f6b)) >> 57;
-    (index as Field).assert_max_bit_size::<32>();
-    MUL_DE_BRUIJN_BIT_64[index as u32]
-}
 
 pub(crate) unconstrained fn get_msb128(x: u128) -> u32 {
     let result = if x == 0 {
@@ -56,143 +26,176 @@ pub(crate) unconstrained fn get_msb128(x: u128) -> u32 {
     result
 }
 
-pub fn assert_msb_equal(x: u64) {
-    let msb64 = unsafe { get_msb64(x) };
-    let msb128 = unsafe { get_msb128(x as u128) };
-    assert_eq(msb64, msb128);
-}
+mod tests {
+    use crate::constants::{TWO_POW_120, TWO_POW_60};
+    use crate::fns::unconstrained_helpers::__get_msb;
+    use super::get_msb128;
 
-#[test]
-// To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
-fn test_get_msb() {
-    // Test case 1: MSB at position 7
-    let x = 0x80; // binary: 10000000
-    assert_msb_equal(x);
-
-    // Test case 2: MSB at position 0
-    let x = 0x1; // binary: 00000001
-    assert_msb_equal(x);
-
-    // Test case 3: MSB at position 63
-    let x = 0x8000000000000000; // binary: 1000...0000 (63 zeros)
-    assert_msb_equal(x);
-
-    // Test case 4: Zero input
-    let x = 0x0;
-    assert_msb_equal(x);
-
-    // Test case 5: All bits set
-    let x = 0xFFFFFFFFFFFFFFFF;
-    assert_msb_equal(x);
-}
-
-unconstrained fn __get_msb64<let N: u32>(val: [u128; N]) -> u32 {
-    let mut count = 0;
-    for i in 0..N {
-        let v = val[((N) - 1 - i)];
-        let v_low = v as u64 % TWO_POW_60 as u64;
-        let v_high = ((v - v_low as u128) / TWO_POW_60) as u64;
-        if (v_high > 0) {
-            count = 60 * ((2 * N) - 1 - (i * 2)) + get_msb64(v_high);
-            break;
-        }
-        if (v_low > 0) {
-            count = 60 * ((2 * N) - 1 - (i * 2 + 1)) + get_msb64(v_low);
-            break;
-        }
-    }
-    count
-}
-
-#[test]
-// To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
-fn test_get_msb_equivalence() {
-    // Test single limb (64-bit number)
-    let x = 0x8000000000000000;
-    let arr = [0, 0, x as u128, 0];
-    let msb1 = unsafe { __get_msb64(arr) };
-    let msb2 = unsafe { __get_msb(arr) };
-    assert_eq(msb1, msb2);
-
-    // Test multiple limbs (120-bit number)
-    let x = 0x800000000000000000000000000000; // 120 bits number
-    let arr = [0, 0, x as u128, 0];
-    let msb1 = unsafe { __get_msb64(arr) };
-    let msb2 = unsafe { __get_msb(arr) };
-    assert_eq(msb1, msb2);
-
-    // Test zero
-    let arr = [0, 0, 0, 0];
-    let msb1 = unsafe { __get_msb64(arr) };
-    let msb2 = unsafe { __get_msb(arr) };
-    assert_eq(msb1, msb2);
-
-    // Test all bits set (120 bits)
-    let x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 120 bits
-    let arr = [0, x as u128, 0, 0];
-    let msb1 = unsafe { __get_msb64(arr) };
-    let msb2 = unsafe { __get_msb(arr) };
-    assert_eq(msb1, msb2);
-
-    // Test systematic bit positions
-    for i in 0..120 {
-        let x: u128 = 1;
-        let shifted = x << i;
-        let arr = [0, shifted, 0, 0];
-        let msb1 = unsafe { __get_msb64(arr) };
-        let msb2 = unsafe { __get_msb(arr) };
-        assert_eq(msb1, msb2);
+    fn assert_msb_equal(x: u64) {
+        let msb64 = unsafe { get_msb64(x) };
+        let msb128 = unsafe { get_msb128(x as u128) };
+        assert_eq(msb64, msb128);
     }
 
-    // Test random-like patterns (multiple bits set)
-    let patterns = [
-        0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // alternating bits
-        0x555555555555555555555555555555, // alternating bits (opposite)
-        0x1234567890ABCDEF1234567890ABCD, // some pattern
-        0xFEDCBA0987654321FEDCBA09876543, // some pattern
-        0x800000000000000000000000000001, // highest and lowest bits
-        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE, // all bits except lowest
-        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFF, // all bits except highest
+    #[test]
+    // To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
+    fn test_get_msb() {
+        // Test case 1: MSB at position 7
+        let x = 0x80; // binary: 10000000
+        assert_msb_equal(x);
+
+        // Test case 2: MSB at position 0
+        let x = 0x1; // binary: 00000001
+        assert_msb_equal(x);
+
+        // Test case 3: MSB at position 63
+        let x = 0x8000000000000000; // binary: 1000...0000 (63 zeros)
+        assert_msb_equal(x);
+
+        // Test case 4: Zero input
+        let x = 0x0;
+        assert_msb_equal(x);
+
+        // Test case 5: All bits set
+        let x = 0xFFFFFFFFFFFFFFFF;
+        assert_msb_equal(x);
+    }
+
+    /// Multiple entires in the `MUL_DE_BRUIJN_BIT` list do not map to a valid output of `v * 0x6c04f118e9966f6b`.
+    /// This is a dummy value to fill the gaps in the map.
+    global n1: u32 = 0xffffffff;
+
+    global MUL_DE_BRUIJN_BIT_64: [u32; 128] = [
+        0, // change to 1 if you want bitSize(0) = 1
+        48, n1, n1, 31, n1, 15, 51, n1, 63, 5, n1, n1, n1, 19, n1, 23, 28, n1, n1, n1, 40, 36, 46,
+        n1, 13, n1, n1, n1, 34, n1, 58, n1, 60, 2, 43, 55, n1, n1, n1, 50, 62, 4, n1, 18, 27, n1,
+        39, 45, n1, n1, 33, 57, n1, 1, 54, n1, 49, n1, 17, n1, n1, 32, n1, 53, n1, 16, n1, n1, 52,
+        n1, n1, n1, 64, 6, 7, 8, n1, 9, n1, n1, n1, 20, 10, n1, n1, 24, n1, 29, n1, n1, 21, n1, 11,
+        n1, n1, 41, n1, 25, 37, n1, 47, n1, 30, 14, n1, n1, n1, n1, 22, n1, n1, 35, 12, n1, n1, n1,
+        59, 42, n1, n1, 61, 3, 26, 38, 44, n1, 56,
     ];
-    for i in 0..patterns.len() {
-        let arr = [0, patterns[i] as u128, 0, 0];
+
+    pub(crate) unconstrained fn get_msb64(x: u64) -> u32 {
+        let mut v = x;
+        v |= v >> 1;
+        v |= v >> 2;
+        v |= v >> 4;
+        v |= v >> 8;
+        v |= v >> 16;
+        v |= v >> 32;
+        let index = (std::wrapping_mul(v, 0x6c04f118e9966f6b)) >> 57;
+        (index as Field).assert_max_bit_size::<32>();
+        MUL_DE_BRUIJN_BIT_64[index as u32]
+    }
+
+    unconstrained fn __get_msb64<let N: u32>(val: [u128; N]) -> u32 {
+        let mut count = 0;
+        for i in 0..N {
+            let v = val[((N) - 1 - i)];
+            let v_low = v as u64 % TWO_POW_60 as u64;
+            let v_high = ((v - v_low as u128) / TWO_POW_60) as u64;
+            if (v_high > 0) {
+                count = 60 * ((2 * N) - 1 - (i * 2)) + get_msb64(v_high);
+                break;
+            }
+            if (v_low > 0) {
+                count = 60 * ((2 * N) - 1 - (i * 2 + 1)) + get_msb64(v_low);
+                break;
+            }
+        }
+        count
+    }
+
+    #[test]
+    // To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
+    fn test_get_msb_equivalence() {
+        // Test single limb (64-bit number)
+        let x = 0x8000000000000000;
+        let arr = [0, 0, x as u128, 0];
         let msb1 = unsafe { __get_msb64(arr) };
         let msb2 = unsafe { __get_msb(arr) };
         assert_eq(msb1, msb2);
-    }
 
-    // Test with MSB in different array positions (120 bits)
-    let x = 0x800000000000000000000000000000; // 120 bits
-    let arr1 = [x as u128, 0, 0, 0];
-    let arr2 = [0, x as u128, 0, 0];
-    let arr3 = [0, 0, x as u128, 0];
-    let arr4 = [0, 0, 0, x as u128];
-    let msb1_1 = unsafe { __get_msb64(arr1) };
-    let msb2_1 = unsafe { __get_msb(arr1) };
-    assert_eq(msb1_1, msb2_1);
+        // Test multiple limbs (120-bit number)
+        let x = 0x800000000000000000000000000000; // 120 bits number
+        let arr = [0, 0, x as u128, 0];
+        let msb1 = unsafe { __get_msb64(arr) };
+        let msb2 = unsafe { __get_msb(arr) };
+        assert_eq(msb1, msb2);
 
-    let msb1_2 = unsafe { __get_msb64(arr2) };
-    let msb2_2 = unsafe { __get_msb(arr2) };
-    assert_eq(msb1_2, msb2_2);
+        // Test zero
+        let arr = [0, 0, 0, 0];
+        let msb1 = unsafe { __get_msb64(arr) };
+        let msb2 = unsafe { __get_msb(arr) };
+        assert_eq(msb1, msb2);
 
-    let msb1_3 = unsafe { __get_msb64(arr3) };
-    let msb2_3 = unsafe { __get_msb(arr3) };
-    assert_eq(msb1_3, msb2_3);
+        // Test all bits set (120 bits)
+        let x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 120 bits
+        let arr = [0, x as u128, 0, 0];
+        let msb1 = unsafe { __get_msb64(arr) };
+        let msb2 = unsafe { __get_msb(arr) };
+        assert_eq(msb1, msb2);
 
-    let msb1_4 = unsafe { __get_msb64(arr4) };
-    let msb2_4 = unsafe { __get_msb(arr4) };
-    assert_eq(msb1_4, msb2_4);
-}
-
-#[test]
-unconstrained fn fuzz_get_msb(seed: [u128; 5]) {
-    let mut seed_copy = seed;
-    for i in 0..5 {
-        if (seed_copy[i] as u128) >= TWO_POW_120 {
-            seed_copy[i] = seed_copy[i] & (TWO_POW_120 - 1);
+        // Test systematic bit positions
+        for i in 0..120 {
+            let x: u128 = 1;
+            let shifted = x << i;
+            let arr = [0, shifted, 0, 0];
+            let msb1 = unsafe { __get_msb64(arr) };
+            let msb2 = unsafe { __get_msb(arr) };
+            assert_eq(msb1, msb2);
         }
+
+        // Test random-like patterns (multiple bits set)
+        let patterns = [
+            0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // alternating bits
+            0x555555555555555555555555555555, // alternating bits (opposite)
+            0x1234567890ABCDEF1234567890ABCD, // some pattern
+            0xFEDCBA0987654321FEDCBA09876543, // some pattern
+            0x800000000000000000000000000001, // highest and lowest bits
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE, // all bits except lowest
+            0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFF, // all bits except highest
+        ];
+        for i in 0..patterns.len() {
+            let arr = [0, patterns[i] as u128, 0, 0];
+            let msb1 = unsafe { __get_msb64(arr) };
+            let msb2 = unsafe { __get_msb(arr) };
+            assert_eq(msb1, msb2);
+        }
+
+        // Test with MSB in different array positions (120 bits)
+        let x = 0x800000000000000000000000000000; // 120 bits
+        let arr1 = [x as u128, 0, 0, 0];
+        let arr2 = [0, x as u128, 0, 0];
+        let arr3 = [0, 0, x as u128, 0];
+        let arr4 = [0, 0, 0, x as u128];
+        let msb1_1 = unsafe { __get_msb64(arr1) };
+        let msb2_1 = unsafe { __get_msb(arr1) };
+        assert_eq(msb1_1, msb2_1);
+
+        let msb1_2 = unsafe { __get_msb64(arr2) };
+        let msb2_2 = unsafe { __get_msb(arr2) };
+        assert_eq(msb1_2, msb2_2);
+
+        let msb1_3 = unsafe { __get_msb64(arr3) };
+        let msb2_3 = unsafe { __get_msb(arr3) };
+        assert_eq(msb1_3, msb2_3);
+
+        let msb1_4 = unsafe { __get_msb64(arr4) };
+        let msb2_4 = unsafe { __get_msb(arr4) };
+        assert_eq(msb1_4, msb2_4);
     }
-    let msb1 = unsafe { __get_msb64(seed_copy) };
-    let msb2 = unsafe { __get_msb(seed_copy) };
-    assert_eq(msb1, msb2);
+
+    #[test]
+    unconstrained fn fuzz_get_msb(seed: [u128; 5]) {
+        let mut seed_copy = seed;
+        for i in 0..5 {
+            if (seed_copy[i] as u128) >= TWO_POW_120 {
+                seed_copy[i] = seed_copy[i] & (TWO_POW_120 - 1);
+            }
+        }
+        let msb1 = unsafe { __get_msb64(seed_copy) };
+        let msb2 = unsafe { __get_msb(seed_copy) };
+        assert_eq(msb1, msb2);
+    }
 }

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -108,32 +108,32 @@ mod tests {
 
     #[test]
     // To check that the msb functions are equivalent with de bruijn sequence for 64 bits and 128 bits
-    fn test_get_msb_equivalence() {
+    unconstrained fn test_get_msb_equivalence() {
         // Test single limb (64-bit number)
         let x = 0x8000000000000000;
         let arr = [0, 0, x as u128, 0];
-        let msb1 = unsafe { __get_msb64(arr) };
-        let msb2 = unsafe { __get_msb(arr) };
+        let msb1 = __get_msb64(arr);
+        let msb2 = __get_msb(arr);
         assert_eq(msb1, msb2);
 
         // Test multiple limbs (120-bit number)
         let x = 0x800000000000000000000000000000; // 120 bits number
         let arr = [0, 0, x as u128, 0];
-        let msb1 = unsafe { __get_msb64(arr) };
-        let msb2 = unsafe { __get_msb(arr) };
+        let msb1 = __get_msb64(arr);
+        let msb2 = __get_msb(arr);
         assert_eq(msb1, msb2);
 
         // Test zero
         let arr = [0, 0, 0, 0];
-        let msb1 = unsafe { __get_msb64(arr) };
-        let msb2 = unsafe { __get_msb(arr) };
+        let msb1 = __get_msb64(arr);
+        let msb2 = __get_msb(arr);
         assert_eq(msb1, msb2);
 
         // Test all bits set (120 bits)
         let x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 120 bits
         let arr = [0, x as u128, 0, 0];
-        let msb1 = unsafe { __get_msb64(arr) };
-        let msb2 = unsafe { __get_msb(arr) };
+        let msb1 = __get_msb64(arr);
+        let msb2 = __get_msb(arr);
         assert_eq(msb1, msb2);
 
         // Test systematic bit positions
@@ -141,8 +141,8 @@ mod tests {
             let x: u128 = 1;
             let shifted = x << i;
             let arr = [0, shifted, 0, 0];
-            let msb1 = unsafe { __get_msb64(arr) };
-            let msb2 = unsafe { __get_msb(arr) };
+            let msb1 = __get_msb64(arr);
+            let msb2 = __get_msb(arr);
             assert_eq(msb1, msb2);
         }
 
@@ -158,8 +158,8 @@ mod tests {
         ];
         for i in 0..patterns.len() {
             let arr = [0, patterns[i] as u128, 0, 0];
-            let msb1 = unsafe { __get_msb64(arr) };
-            let msb2 = unsafe { __get_msb(arr) };
+            let msb1 = __get_msb64(arr);
+            let msb2 = __get_msb(arr);
             assert_eq(msb1, msb2);
         }
 
@@ -169,20 +169,20 @@ mod tests {
         let arr2 = [0, x as u128, 0, 0];
         let arr3 = [0, 0, x as u128, 0];
         let arr4 = [0, 0, 0, x as u128];
-        let msb1_1 = unsafe { __get_msb64(arr1) };
-        let msb2_1 = unsafe { __get_msb(arr1) };
+        let msb1_1 = __get_msb64(arr1);
+        let msb2_1 = __get_msb(arr1);
         assert_eq(msb1_1, msb2_1);
 
-        let msb1_2 = unsafe { __get_msb64(arr2) };
-        let msb2_2 = unsafe { __get_msb(arr2) };
+        let msb1_2 = __get_msb64(arr2);
+        let msb2_2 = __get_msb(arr2);
         assert_eq(msb1_2, msb2_2);
 
-        let msb1_3 = unsafe { __get_msb64(arr3) };
-        let msb2_3 = unsafe { __get_msb(arr3) };
+        let msb1_3 = __get_msb64(arr3);
+        let msb2_3 = __get_msb(arr3);
         assert_eq(msb1_3, msb2_3);
 
-        let msb1_4 = unsafe { __get_msb64(arr4) };
-        let msb2_4 = unsafe { __get_msb(arr4) };
+        let msb1_4 = __get_msb64(arr4);
+        let msb2_4 = __get_msb(arr4);
         assert_eq(msb1_4, msb2_4);
     }
 
@@ -192,8 +192,8 @@ mod tests {
         for i in 0..5 {
             seed_copy[i] = seed_copy[i] & (TWO_POW_120 - 1);
         }
-        let msb1 = unsafe { __get_msb64(seed_copy) };
-        let msb2 = unsafe { __get_msb(seed_copy) };
+        let msb1 = __get_msb64(seed_copy);
+        let msb2 = __get_msb(seed_copy);
         assert_eq(msb1, msb2);
     }
 }

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -86,7 +86,7 @@ fn test_get_msb() {
     assert_msb_equal(x);
 }
 
-pub(crate) unconstrained fn __get_msb64<let N: u32>(val: [u128; N]) -> u32 {
+unconstrained fn __get_msb64<let N: u32>(val: [u128; N]) -> u32 {
     let mut count = 0;
     for i in 0..N {
         let v = val[((N) - 1 - i)];

--- a/src/utils/msb.nr
+++ b/src/utils/msb.nr
@@ -184,7 +184,6 @@ fn test_get_msb_equivalence() {
     assert_eq(msb1_4, msb2_4);
 }
 
-/*
 #[test]
 unconstrained fn fuzz_get_msb(seed: [u128; 5]) {
     let mut seed_copy = seed;
@@ -197,4 +196,3 @@ unconstrained fn fuzz_get_msb(seed: [u128; 5]) {
     let msb2 = unsafe { __get_msb(seed_copy) };
     assert_eq(msb1, msb2);
 }
-*/


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir-bignum/issues/136

## Summary\*

Working on implementing and testing the __get_msb function to work similarly to __get_msb64 but using get_msb128 directly.

Found a working 128-bit de bruijn sequence with no collision by brute force.


## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
