### PR TITLE
feat: remove conditional select from Bignum

### DIFF
--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -290,11 +290,11 @@ pub(crate) comptime fn derive_bignum_impl(
 }
 
 pub fn conditional_select<T: BigNum>(lhs: T, rhs: T, predicate: bool) -> T {
-    T::from_limbs(crate::fns::constrained_ops::conditional_select(
-        lhs.get_limbs(),
-        rhs.get_limbs(),
-        predicate,
-    ))
+    if predicate {
+        lhs
+    } else {
+        rhs
+    }
 }
 
 pub unconstrained fn compute_quadratic_expression<T: BigNum, let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32, let ADD_N: u32>(

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -95,7 +95,7 @@ pub(crate) fn from_field<let N: u32, let MOD_BITS: u32>(
                     }
                 }
             }
-            let result_2 = conditional_select::<N>(_params.modulus, grumpkin_modulus, gt_grumpkin);
+            let result_2 = if gt_grumpkin {_params.modulus} else {grumpkin_modulus};
             validate_gt::<N, MOD_BITS>(result_2, result);
         }
 
@@ -230,24 +230,6 @@ pub(crate) fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32
         result = add(params, result, bigfield_lhs_limbs);
     }
 
-    result
-}
-
-/**
-* @brief conditional_select given the value of `predicate` return either `self` (if 0) or `other` (if 1)
-* @description should be cheaper than using an IF statement (TODO: check!)
-**/
-pub(crate) fn conditional_select<let N: u32>(
-    lhs: [u128; N],
-    rhs: [u128; N],
-    predicate: bool,
-) -> [u128; N] {
-    let mut result: [u128; N] = lhs;
-    for i in 0..N {
-        // (lhs[i] - rhs[i]) * predicate + rhs[i]
-        // in case lhs < rhs, this will underflow so we have to do one extra multiplication to prevent it
-        result[i] = lhs[i] * predicate as u128 + rhs[i] * (1 - predicate as u128);
-    }
     result
 }
 

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -95,7 +95,11 @@ pub(crate) fn from_field<let N: u32, let MOD_BITS: u32>(
                     }
                 }
             }
-            let result_2 = if gt_grumpkin {_params.modulus} else {grumpkin_modulus};
+            let result_2 = if gt_grumpkin {
+                _params.modulus
+            } else {
+                grumpkin_modulus
+            };
             validate_gt::<N, MOD_BITS>(result_2, result);
         }
 

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -364,9 +364,6 @@ pub fn conditional_select<let N: u32, let MOD_BITS: u32>(
 ) -> RuntimeBigNum<N, MOD_BITS> {
     let params = lhs.params;
     assert(params == rhs.params);
-    let limbs = if predicate {lhs.limbs} else {rhs.limbs};
-    RuntimeBigNum {
-        limbs: limbs,
-        params,
-    }
+    let limbs = if predicate { lhs.limbs } else { rhs.limbs };
+    RuntimeBigNum { limbs: limbs, params }
 }

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -364,8 +364,9 @@ pub fn conditional_select<let N: u32, let MOD_BITS: u32>(
 ) -> RuntimeBigNum<N, MOD_BITS> {
     let params = lhs.params;
     assert(params == rhs.params);
+    let limbs = if predicate {lhs.limbs} else {rhs.limbs};
     RuntimeBigNum {
-        limbs: crate::fns::constrained_ops::conditional_select(lhs.limbs, rhs.limbs, predicate),
+        limbs: limbs,
         params,
     }
 }


### PR DESCRIPTION
# Description

Simplifies the conditional_select function by replacing the arithmetic-based selection logic with a simple if-statement. As shown in https://github.com/noir-lang/noir-bignum/pull/184, this change improves circuit size benchmarks.

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
