### PR TITLE
fix: allow bignum derivation function to run in other crates

### DIFF
--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -67,7 +67,7 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
 }
 
 // we need macros that implement the BigNum, Default, From, Neg, Add, Sub, Mul, Div, Eq, Ord traits for each bignum type
-pub(crate) comptime fn derive_bignum_impl(
+pub comptime fn derive_bignum_impl(
     strukt: TypeDefinition,
     N: u32,
     MOD_BITS: u32,

--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -73,10 +73,10 @@ pub(crate) comptime fn derive_bignum_impl(
     MOD_BITS: u32,
     params: Quoted,
 ) -> Quoted {
-    let constrained_ops = quote { crate::fns::constrained_ops };
-    let unconstrained_ops = quote { crate::fns::unconstrained_ops };
+    let constrained_ops = quote { $crate::fns::constrained_ops };
+    let unconstrained_ops = quote { $crate::fns::unconstrained_ops };
     let typ = strukt.as_type();
-    let serialization = quote { crate::fns::serialization };
+    let serialization = quote { $crate::fns::serialization };
     quote {
 
         // implement BigNum for BigNum 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the macro to use https://github.com/noir-lang/noir/pull/8537 so that it can be run in external crates


## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
