### PR TITLE
fix: correct from_field and derive_from_seed for small field modulus

### DIFF
--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -222,7 +222,8 @@ pub(crate) fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32
                 bigfield_limbs[num_limbs_in_bigfield - 1 - j] = limb;
             }
             bigfield_chunks[num_bigfield_chunks - 1 - k] = bigfield_limbs;
-    }}
+        }
+    }
 
     let mut bigfield_rhs_limbs: [u128; N] = [0; N];
     bigfield_rhs_limbs[N - 1] = 1;


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
