### PR TITLE
fix: let the bignum module be public

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,4 +1,4 @@
-mod bignum;
+pub mod bignum;
 mod runtime_bignum;
 
 mod constants;


### PR DESCRIPTION
# Description

## Problem

There's otherwise no way to refer to the public functions it has, like `compute_quadratic_expression`, `evaluate_quadratic_expression` and `batch_invert`.

## Summary

Right now they can be referenced without an error because of a bug in Noir. Once https://github.com/noir-lang/noir/pull/9295 that will error. 

## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
