### PR TITLE
chore: Bump to Noir v1.0.0-beta.11

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.4
         with:
-          toolchain: nightly-2025-08-15
+          toolchain: 1.0.0-beta.11
 
       - name: Install bb
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MINIMUM_NOIR_VERSION: nightly-2025-08-15
+  MINIMUM_NOIR_VERSION: 1.0.0-beta.11
 
 jobs:
   noir-version-list:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For the arithmetic operations it is important to notice the difference between c
 
 ## Noir Version Compatibility
 
-This library is tested with all stable releases since 1.0.0-beta.7 as well as nightly.
+This library is tested with all stable releases since 1.0.0-beta.11 as well as nightly.
 
 Refer to [Noir's docs](https://noir-lang.org/docs/getting_started/noir_installation) for installation steps.
 


### PR DESCRIPTION
# Description

## Problem\*

From https://github.com/noir-lang/noir-bignum/pull/196 onwards, this library is only compatible with Noir ≥v1.0.0-beta.11.

## Summary\*

Bump repo to use Noir v1.0.0-beta.11.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
