### PR TITLE
chore: (unconstrained_ops) document and clean up `__derive_from_seed` and comparison functions

### DIFF
--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -30,26 +30,12 @@ pub(crate) unconstrained fn __derive_from_seed<let N: u32, let MOD_BITS: u32, le
 
 /// Compare two limb arrays for equality (unconstrained)
 pub(crate) unconstrained fn __eq<let N: u32>(lhs: [u128; N], rhs: [u128; N]) -> bool {
-    let mut result: bool = true;
-    for i in 0..N {
-        if lhs[i] != rhs[i] {
-            result = false;
-            break;
-        }
-    }
-    result
+    lhs == rhs
 }
 
 /// Compare a limb array to a zero array (unconstrained)
 pub(crate) unconstrained fn __is_zero<let N: u32>(limbs: [u128; N]) -> bool {
-    let mut result: bool = true;
-    for i in 0..N {
-        if limbs[i] != 0 {
-            result = false;
-            break;
-        }
-    }
-    result
+    limbs == [0; N]
 }
 
 /// Compare two little-endian limb arrays for `lhs >= rhs` over integers (unconstrained)


### PR DESCRIPTION
# Description

This PR adds documentation for the `__derive_from_seed`, `__eq`, `__is_zero` and `__gte` functions and also cleans them up(tiny reduction in brillig opcodes)

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
