### PR TITLE
feat: clean up and optimize `__barrett_reduction`

### DIFF
--- a/src/fns/unconstrained_helpers.nr
+++ b/src/fns/unconstrained_helpers.nr
@@ -227,6 +227,46 @@ comptime global BARRETT_REDUCTION_OVERFLOW_BITS: u32 = 4;
 ///      N must be large enough to cover the modulus *plus* BARRETT_REDUCTION_OVERFLOW_BITS
 ///      i.e. a 359-bit prime needs (I think) 4 limbs to represent or we may overflow
 ///      when calling __barrett_reduction
+///
+/// ## Note on final reduction
+///
+/// Assumptions:
+///  - k = ceil(log2 p), so p <= 2^k
+///  - s = 4, m = redc_param = floor(2^{2*k + s}/p)
+///  - x < 16 * p^2 (x < 2^{2 * k + s})
+///
+/// Let m' = 2^{2*k + s} / p, and write m = m' - \epsilon, \epsilon \in [0, 1)
+//
+/// quo = floor(x * m / 2^{2 * k + s}) = floor(x * m' / 2^{2 * k + s} - x * \epsilon / 2^{2 * k + s}) =
+/// floor(x / p - x * \epsilon / 2^{2 * k + s})
+///
+/// Bounds:
+///   quo <= floor(x / p)
+///
+///   floor(a - b) >= floor(a) - ceil(b) (known identity) =>
+///   quo >= floor(x / p) - ceil(x * \epsilon / 2^{2 * k + s})
+///       >= floor(x / p) - ceil(x / 2^{2 * k + s}) (epsilon < 1)
+///
+/// x / 2^{2 * k + s} < C * p^2 / 2^{2 * k + s} <= C * 2^{2 * k} / 2^{2 * k + s} = C / 2^s
+///
+/// When the assumption holds (C = 16), ceil(x / 2^{2 * k + s}) = 1, for x > 0
+/// Therefore quo = {floor(x/p), floor(x/p) - 1}
+///
+/// In first case: rem = x - quo * p = x - floor(x/p) * p < p
+/// In second case: rem = x - (floor(x/p) - 1) * p = (x - floor(x/p) * p) + p -> need 1 subtraction
+///
+/// ### Note
+/// We allow 64 products to be summed inside the `evaluate_quadratic_expression`
+/// In that case x / 2^{2 * k + s} < 64 / 2^4 = 4 => hence we need to subtract modulus at most 4 times
+/// We can leave it 2 for now as it is unlikely to reach beyond 32 * p^2
+///
+/// In the worst case though, we will have the input > 64 * p^2
+/// (for example (a1 + b1) * (c1 + d1) + ... 64 times)
+/// This is highly unlikely though.
+///
+/// ### TODO:
+/// Possibly change the `BARRETT_REDUCTION_OVERFLOW_BITS` to 6, so that we need only 1 reduction here
+/// However we will have to recompute all the fields `redc_param`s and fix paramgen
 pub(crate) unconstrained fn __barrett_reduction<let N: u32>(
     x: [u128; 2 * N],
     redc_param: [u128; N],
@@ -260,45 +300,7 @@ pub(crate) unconstrained fn __barrett_reduction<let N: u32>(
         remainder[i] = long_remainder[i];
     }
 
-    // We need at most one reduction here:
-    //
-    // Assumptions:
-    //  - k = ceil(log2 p), so p <= 2^k
-    //  - s = 4, m = redc_param = floor(2^{2*k + s}/p)
-    //  - x < 16 * p^2 (x < 2^{2 * k + s})
-    //
-    // Let m' = 2^{2*k + s} / p, and write m = m' - \epsilon, \epsilon \in [0, 1)
-    //
-    // quo = floor(x * m / 2^{2 * k + s}) = floor(x * m' / 2^{2 * k + s} - x * \epsilon / 2^{2 * k + s}) =
-    // floor(x / p - x * \epsilon / 2^{2 * k + s})
-    //
-    // Bounds:
-    //   quo <= floor(x / p)
-    //
-    //   floor(a - b) >= floor(a) - ceil(b) (known identity) =>
-    //   quo >= floor(x / p) - ceil(x * \epsilon / 2^{2 * k + s})
-    //       >= floor(x / p) - ceil(x / 2^{2 * k + s}) (epsilon < 1)
-    //
-    // x / 2^{2 * k + s} < C * p^2 / 2^{2 * k + s} <= C * 2^{2 * k} / 2^{2 * k + s} = C / 2^s
-    //
-    // When the assumption holds (C = 16), ceil(x / 2^{2 * k + s}) = 1, for x > 0
-    // Therefore quo = {floor(x/p), floor(x/p) - 1}
-    //
-    // In first case: rem = x - quo * p = x - floor(x/p) * p < p
-    // In second case: rem = x - (floor(x/p) - 1) * p = (x - floor(x/p) * p) + p -> need 1 subtraction
-    //
-    // NOTE
-    // We allow 64 products to be summed inside the `evaluate_quadratic_expression`
-    // In that case x / 2^{2 * k + s} < 64 / 2^4 = 4 => hence we need to subtract modulus at most 4 times
-    // We can leave it 2 for now
-    //
-    // In the worst case though, we will have the input > 64 * p^2
-    // (for example (a1 + b1) * (c1 + d1) + ... 64 times)
-    // This is highly unlikely though.
-    //
-    // TODO: Possibly change the `BARRETT_REDUCTION_OVERFLOW_BITS` to 6, so that we need only 1 reduction here
-    //       However we will have to recompute all the fields `redc_param`s and fix paramgen
-    for i in 0..2 {
+    for _ in 0..2 {
         if (__gte(remainder, modulus)) {
             remainder = __helper_sub(remainder, modulus);
             smaller_quotient = __increment(smaller_quotient);


### PR DESCRIPTION
# Description

This PR adds documentation and cleans up the `__barrett_reduction` function.

Large docstring was added, explaining the final modulus subtraction. 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
