### PR TITLE
chore(serialization): Clean up, document and optimize BigNum serialization

### DIFF
--- a/src/fns/serialization.nr
+++ b/src/fns/serialization.nr
@@ -67,19 +67,19 @@ pub(crate) fn to_be_bytes<let N: u32, let MOD_BITS: u32>(
 ) -> [u8; (MOD_BITS + 7) / 8] {
     let mut result: [u8; (MOD_BITS + 7) / 8] = [0; (MOD_BITS + 7) / 8];
 
-    let last_limb_bytes: [u8; ((MOD_BITS + 7) / 8 - (N - 1) * 15)] =
-        (val[N - 1] as Field).to_be_bytes();
-
-    for i in 0..((MOD_BITS + 7) / 8 - (N - 1) * 15) {
-        result[i] = last_limb_bytes[i];
-    }
-
     for i in 0..N - 1 {
         let index = N - i - 2;
         let limb_bytes: [u8; 15] = (val[index] as Field).to_be_bytes();
         for j in 0..15 {
             result[i * 15 + j + (MOD_BITS + 7) / 8 - (N - 1) * 15] = limb_bytes[j];
         }
+    }
+
+    let last_limb_bytes: [u8; ((MOD_BITS + 7) / 8 - (N - 1) * 15)] =
+        (val[N - 1] as Field).to_be_bytes();
+
+    for i in 0..((MOD_BITS + 7) / 8 - (N - 1) * 15) {
+        result[i] = last_limb_bytes[i];
     }
     result
 }


### PR DESCRIPTION
# Description

This PR adds documentation and optimizes the following functions: `from_be_bytes`, `to_be_bytes`, `from_le_bytes`, `to_le_bytes`

Also optimizes the range constraints to be 120 bits not 128

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
