### PR TITLE
chore(serialization): Cleanup, document and optimize BigNum serialization

### DIFF
--- a/src/fns/serialization.nr
+++ b/src/fns/serialization.nr
@@ -35,6 +35,9 @@ pub(crate) fn from_be_bytes<let N: u32, let MOD_BITS: u32>(
         limb *= 256;
         limb += x[i] as Field;
     }
+
+    // TODO: Figure out why is it more efficient to apply 120-bit range constraint here
+    // Rather than `MOD_BITS - 120 * (N - 1)`-bit constraint
     limb.assert_max_bit_size::<120>();
     result[N - 1] = limb as u128;
 
@@ -50,9 +53,10 @@ pub(crate) fn from_be_bytes<let N: u32, let MOD_BITS: u32>(
         result[N - i - 1] = limb as u128;
     }
 
-    let most_significant_byte: Field = x[0] as Field;
-
-    most_significant_byte.assert_max_bit_size::<8 - ((MOD_BITS + 7) / 8 * 8 - MOD_BITS)>();
+    if (MOD_BITS % 8 != 0) {
+        let most_significant_byte: Field = x[0] as Field;
+        most_significant_byte.assert_max_bit_size::<MOD_BITS % 8>();
+    }
     result
 }
 


### PR DESCRIPTION
# Description

This PR adds documentation and optimizes the following functions: `from_be_bytes`, `to_be_bytes`, `from_le_bytes`, `to_le_bytes`

Additionally changes 128-bit constraints in `from_be_bytes` to 120-bit constraints 
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
