### PR TITLE
fix(expressions): Document, clean up and restructure `evaluate_quadratic_expression`

### DIFF
--- a/src/fns/expressions.nr
+++ b/src/fns/expressions.nr
@@ -584,7 +584,7 @@ pub(crate) fn evaluate_quadratic_expression<let N: u32, let MOD_BITS: u32, let L
     });
     linear_terms.for_each(|term: [u128; N]| validate_in_range::<u128, N, MOD_BITS>(term));
 
-    let mut product_limbs: [Field; 2 * N - 1] = compute_quadratic_expression_with_modulus::<N, MOD_BITS, LHS_N, RHS_N, NUM_PRODUCTS, ADD_N>(
+    let product_limbs: [Field; 2 * N - 1] = compute_quadratic_expression_with_modulus::<N, MOD_BITS, LHS_N, RHS_N, NUM_PRODUCTS, ADD_N>(
         params,
         lhs_terms,
         lhs_flags,

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -2,7 +2,6 @@ use crate::bignum::BigNum;
 use crate::bignum::{compute_quadratic_expression, evaluate_quadratic_expression, to_field};
 use crate::bignum::derive_bignum;
 use crate::fns::unconstrained_helpers::__helper_add;
-use crate::fns::unconstrained_ops::__div;
 
 use crate::params::BigNumParams;
 


### PR DESCRIPTION
# Description

This PR splits `evaluate_quadratic_expression` into three parts:

- `compute_linear_expressions` - in-circuit addition/negation of `BigNum` limbs
- `compute_quadratic_expression_with_modulus` - compute `EXPR - quo * MOD` with borrow flags
- `validate_expression_is_zero` - function that takes a `[2 * N - 1; Field]` array and enforces it to be a zero array

All these functions now go with a huge docstring

## Fix

Previously it was possible to provide the witness containing a `BigNum` that differs from a real value by `k * MOD`. Now k can be at most 1 as in the rest of the library.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
