### PR TITLE
fix: make quoted modules and functions visible to external libraries

### DIFF
--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -52,7 +52,7 @@ pub(crate) fn limbs_to_field<let N: u32, let MOD_BITS: u32>(
 ///     - MOD_BITS = 253: verify that `val < min(MOD, GRUMPKIN_MODULUS)`
 /// Next we verify that all the limbs are properly ranged
 /// and that the accumulated limbs are equal to the input `Field` value
-pub(crate) fn from_field<let N: u32, let MOD_BITS: u32>(
+pub fn from_field<let N: u32, let MOD_BITS: u32>(
     _params: BigNumParams<N, MOD_BITS>,
     val: Field,
 ) -> [u128; N] {
@@ -131,7 +131,7 @@ pub(crate) fn from_field<let N: u32, let MOD_BITS: u32>(
 /// This function will always produce an `x3` `BigNum`
 /// If `MOD = 2^{120 * (N - 1)}`
 /// It will use only `MOD_BITS - 1` bits of entropy
-pub(crate) fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32>(
+pub fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32>(
     params: BigNumParams<N, MOD_BITS>,
     seed: [u8; SeedBytes],
 ) -> [u128; N] {
@@ -290,7 +290,7 @@ pub(crate) fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32
 /// roughly 3/p.
 ///
 /// In case `MOD` < `p` this function becomes *complete*
-pub(crate) fn assert_is_not_equal<let N: u32, let MOD_BITS: u32>(
+pub fn assert_is_not_equal<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -327,7 +327,7 @@ pub(crate) fn assert_is_not_equal<let N: u32, let MOD_BITS: u32>(
 ///
 /// ## TODO
 /// can do this more efficiently via witngen in unconstrained functions?
-pub(crate) fn eq<let N: u32, let MOD_BITS: u32>(
+pub fn eq<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -361,7 +361,7 @@ pub(crate) fn eq<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// This is slightly cheaper than doing `val != [0; N]`, as we avoid
 /// creating per-limb boolean equalities and chaining them with `and`s.
-pub(crate) fn assert_is_not_zero_integer<let N: u32>(val: [u128; N]) {
+pub fn assert_is_not_zero_integer<let N: u32>(val: [u128; N]) {
     let mut limb_sum: Field = 0;
     for i in 0..N {
         limb_sum += val[i] as Field;
@@ -379,7 +379,7 @@ pub(crate) fn assert_is_not_zero_integer<let N: u32>(val: [u128; N]) {
 /// ## Note
 /// This is slightly cheaper than testing `val == [0; N]`, as we avoid
 /// creating per-limb boolean equalities and chaining them with `and`s.
-pub(crate) fn is_zero_integer<let N: u32>(val: [u128; N]) -> bool {
+pub fn is_zero_integer<let N: u32>(val: [u128; N]) -> bool {
     let mut limb_sum: Field = 0;
     for i in 0..N {
         limb_sum += val[i] as Field;
@@ -390,7 +390,7 @@ pub(crate) fn is_zero_integer<let N: u32>(val: [u128; N]) -> bool {
 /// Validate that a `BigNum` value is not zero modulo `MOD`.
 ///
 /// Convenience wrapper around `assert_is_not_equal`.
-pub(crate) fn assert_is_not_zero<let N: u32, let MOD_BITS: u32>(
+pub fn assert_is_not_zero<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) {
@@ -406,7 +406,7 @@ pub(crate) fn assert_is_not_zero<let N: u32, let MOD_BITS: u32>(
 ///
 /// ## Note
 /// This is cheaper than calling `eq(val, [0; N])`
-pub(crate) fn is_zero<let N: u32, let MOD_BITS: u32>(
+pub fn is_zero<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) -> bool {
@@ -430,7 +430,7 @@ pub(crate) fn is_zero<let N: u32, let MOD_BITS: u32>(
 /// It is nicely decomposed into
 /// 14-bit range check and 3-bit range check - much much cheaper, since 14-bit range checks
 /// are already pretty common for 120-bit range checks
-pub(crate) fn validate_in_range<T, let N: u32, let MOD_BITS: u32>(limbs: [T; N])
+pub fn validate_in_range<T, let N: u32, let MOD_BITS: u32>(limbs: [T; N])
 where
     T: Into<Field>,
 {
@@ -543,7 +543,7 @@ pub(crate) fn check_gte_with_flags<let N: u32>(
 /// ## Note
 /// In contrast to `validate_gt`, we allow the value to be `MOD`
 /// Since it is consistent with the rest of the library
-pub(crate) fn validate_in_field<let N: u32, let MOD_BITS: u32>(
+pub fn validate_in_field<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) {
@@ -573,7 +573,7 @@ pub(crate) fn validate_in_field<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// This is a strict value comparison over the integers,
 /// the values do not have to be reduced modulo `MOD`.
-pub(crate) fn cmp<let N: u32, let MOD_BITS: u32>(lhs: [u128; N], rhs: [u128; N]) -> Ordering {
+pub fn cmp<let N: u32, let MOD_BITS: u32>(lhs: [u128; N], rhs: [u128; N]) -> Ordering {
     // Safety: we constrain:
     //        - `result` and `borrow_flags` with `check_gte_with_flags`
     //        - `borrow_flags` are also booleans
@@ -633,7 +633,7 @@ pub(crate) fn cmp<let N: u32, let MOD_BITS: u32>(lhs: [u128; N], rhs: [u128; N])
 ///
 /// ## Note
 /// This function returns `MOD` when `val` is zero.
-pub(crate) fn neg<let N: u32, let MOD_BITS: u32>(
+pub fn neg<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) -> [u128; N] {
@@ -770,7 +770,7 @@ pub(crate) fn neg<let N: u32, let MOD_BITS: u32>(
 /// as limb arrays and may admit satisfying witnesses, but then the operation
 /// no longer corresponds to a unique, well-defined addition in the field
 /// `Z / MOD Z`. Such uses are outside the intended semantics of this function.
-pub(crate) fn add<let N: u32, let MOD_BITS: u32>(
+pub fn add<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -918,7 +918,7 @@ pub(crate) fn add<let N: u32, let MOD_BITS: u32>(
 /// as limb arrays and may admit satisfying witnesses, but then the operation
 /// no longer corresponds to a unique, well-defined subtraction in the field
 /// `Z / MOD Z`. Such uses are outside the intended semantics of this function.
-pub(crate) fn sub<let N: u32, let MOD_BITS: u32>(
+pub fn sub<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -980,7 +980,7 @@ pub(crate) fn sub<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// When possible, prefer expressing your computation directly as a quadratic
 ///   relation and calling `evaluate_quadratic_expression` instead of using `mul`
-pub(crate) fn mul<let N: u32, let MOD_BITS: u32>(
+pub fn mul<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -1016,7 +1016,7 @@ pub(crate) fn mul<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// When possible, prefer expressing your computation directly as a quadratic
 ///   relation and calling `evaluate_quadratic_expression` instead of using `sqr`
-pub(crate) fn sqr<let N: u32, let MOD_BITS: u32>(
+pub fn sqr<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) -> [u128; N] {
@@ -1057,7 +1057,7 @@ pub(crate) fn sqr<let N: u32, let MOD_BITS: u32>(
 ///   relation and calling `evaluate_quadratic_expression` instead of using `div`.
 /// - In the unconstrained runtime, the behavior of `__div` on zero divisors is
 ///   not constrained by this function.
-pub(crate) fn div<let N: u32, let MOD_BITS: u32>(
+pub fn div<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -1106,7 +1106,7 @@ pub(crate) fn div<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// Enforcing `divisor != 0` is not necessary. `remainder < divisor`
 /// Already enforces this.
-pub(crate) fn udiv_mod<let N: u32, let MOD_BITS: u32>(
+pub fn udiv_mod<let N: u32, let MOD_BITS: u32>(
     numerator: [u128; N],
     divisor: [u128; N],
 ) -> ([u128; N], [u128; N]) {
@@ -1125,10 +1125,7 @@ pub(crate) fn udiv_mod<let N: u32, let MOD_BITS: u32>(
 ///
 /// Returns `floor(numerator / divisor)`.
 /// All constraints and soundness details are handled inside `udiv_mod`.
-pub(crate) fn udiv<let N: u32, let MOD_BITS: u32>(
-    numerator: [u128; N],
-    divisor: [u128; N],
-) -> [u128; N] {
+pub fn udiv<let N: u32, let MOD_BITS: u32>(numerator: [u128; N], divisor: [u128; N]) -> [u128; N] {
     udiv_mod::<N, MOD_BITS>(numerator, divisor).0
 }
 
@@ -1136,9 +1133,6 @@ pub(crate) fn udiv<let N: u32, let MOD_BITS: u32>(
 ///
 /// Returns `numerator % divisor`.
 /// All constraints and soundness details are handled inside `udiv_mod`.
-pub(crate) fn umod<let N: u32, let MOD_BITS: u32>(
-    numerator: [u128; N],
-    divisor: [u128; N],
-) -> [u128; N] {
+pub fn umod<let N: u32, let MOD_BITS: u32>(numerator: [u128; N], divisor: [u128; N]) -> [u128; N] {
     udiv_mod::<N, MOD_BITS>(numerator, divisor).1
 }

--- a/src/fns/mod.nr
+++ b/src/fns/mod.nr
@@ -1,6 +1,6 @@
 // Free functions called by structs
-pub(crate) mod unconstrained_ops;
-pub(crate) mod constrained_ops;
+pub mod unconstrained_ops;
+pub mod constrained_ops;
 pub(crate) mod unconstrained_helpers;
 pub(crate) mod expressions;
-pub(crate) mod serialization;
+pub mod serialization;

--- a/src/fns/serialization.nr
+++ b/src/fns/serialization.nr
@@ -20,9 +20,7 @@ use crate::utils::map::invert_array;
 /// In principle, accumulating `u8` values already bounds the integer,
 /// but relying on Noir to infer a `u128` from a large linear combination
 /// would trigger a very general (and expensive) range checks
-pub(crate) fn from_be_bytes<let N: u32, let MOD_BITS: u32>(
-    x: [u8; (MOD_BITS + 7) / 8],
-) -> [u128; N] {
+pub fn from_be_bytes<let N: u32, let MOD_BITS: u32>(x: [u8; (MOD_BITS + 7) / 8]) -> [u128; N] {
     let num_bytes: u32 = (MOD_BITS + 7) / 8;
 
     let mut result: [u128; N] = [0; N];
@@ -69,9 +67,7 @@ pub(crate) fn from_be_bytes<let N: u32, let MOD_BITS: u32>(
 /// Consistency between `N` and `MOD_BITS` is expected:
 ///     - the most significant limb contributes `((MOD_BITS + 7) / 8) - (N - 1) * 15` bytes;
 ///     - all other limbs are serialized as full 15-byte chunks.
-pub(crate) fn to_be_bytes<let N: u32, let MOD_BITS: u32>(
-    val: [u128; N],
-) -> [u8; (MOD_BITS + 7) / 8] {
+pub fn to_be_bytes<let N: u32, let MOD_BITS: u32>(val: [u128; N]) -> [u8; (MOD_BITS + 7) / 8] {
     let mut result: [u8; (MOD_BITS + 7) / 8] = [0; (MOD_BITS + 7) / 8];
 
     let last_limb_num_bytes: u32 = (MOD_BITS + 7) / 8 - (N - 1) * 15;
@@ -100,9 +96,7 @@ pub(crate) fn to_be_bytes<let N: u32, let MOD_BITS: u32>(
 /// Reverse an array and apply `from_be_bytes`
 ///
 /// See `from_be_bytes` for details
-pub(crate) fn from_le_bytes<let N: u32, let MOD_BITS: u32>(
-    x: [u8; (MOD_BITS + 7) / 8],
-) -> [u128; N] {
+pub fn from_le_bytes<let N: u32, let MOD_BITS: u32>(x: [u8; (MOD_BITS + 7) / 8]) -> [u128; N] {
     let be_x: [u8; (MOD_BITS + 7) / 8] = invert_array(x);
     from_be_bytes(be_x)
 }
@@ -112,9 +106,7 @@ pub(crate) fn from_le_bytes<let N: u32, let MOD_BITS: u32>(
 /// Apply `to_be_bytes` and reverse an array
 ///
 /// See `to_be_bytes` for details
-pub(crate) fn to_le_bytes<let N: u32, let MOD_BITS: u32>(
-    val: [u128; N],
-) -> [u8; (MOD_BITS + 7) / 8] {
+pub fn to_le_bytes<let N: u32, let MOD_BITS: u32>(val: [u128; N]) -> [u8; (MOD_BITS + 7) / 8] {
     let result_be: [u8; (MOD_BITS + 7) / 8] = to_be_bytes(val);
     invert_array(result_be)
 }

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -19,7 +19,7 @@ use crate::params::BigNumParams;
 /// Takes a seed byte array and generates a `BigNum` in the range [0, modulus-1].
 ///
 /// See more information in `constrained_ops.nr`: `derive_from_seed`
-pub(crate) unconstrained fn __derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32>(
+pub unconstrained fn __derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32>(
     params: BigNumParams<N, MOD_BITS>,
     seed: [u8; SeedBytes],
 ) -> [u128; N] {
@@ -29,12 +29,12 @@ pub(crate) unconstrained fn __derive_from_seed<let N: u32, let MOD_BITS: u32, le
 // ------------------------------ COMPARISON FUNCTIONS ------------------------------
 
 /// Compare two limb arrays for equality (unconstrained)
-pub(crate) unconstrained fn __eq<let N: u32>(lhs: [u128; N], rhs: [u128; N]) -> bool {
+pub unconstrained fn __eq<let N: u32>(lhs: [u128; N], rhs: [u128; N]) -> bool {
     lhs == rhs
 }
 
 /// Compare a limb array to a zero array (unconstrained)
-pub(crate) unconstrained fn __is_zero<let N: u32>(limbs: [u128; N]) -> bool {
+pub unconstrained fn __is_zero<let N: u32>(limbs: [u128; N]) -> bool {
     limbs == [0; N]
 }
 
@@ -60,7 +60,7 @@ pub(crate) unconstrained fn __gte<let N: u32>(lhs: [u128; N], rhs: [u128; N]) ->
 ///
 /// ## Note
 /// The input is assumed to be less than modulus
-pub(crate) unconstrained fn __neg<let N: u32>(modulus: [u128; N], limbs: [u128; N]) -> [u128; N] {
+pub unconstrained fn __neg<let N: u32>(modulus: [u128; N], limbs: [u128; N]) -> [u128; N] {
     __helper_sub(modulus, limbs)
 }
 
@@ -72,7 +72,7 @@ pub(crate) unconstrained fn __neg<let N: u32>(modulus: [u128; N], limbs: [u128; 
 /// ## Note
 /// The `carry` must be `0` at the end of the loop.
 /// No explicit assertion is made, as this condition is validated during evaluation.
-pub(crate) unconstrained fn __add<let N: u32>(
+pub unconstrained fn __add<let N: u32>(
     modulus: [u128; N],
     lhs: [u128; N],
     rhs: [u128; N],
@@ -98,7 +98,7 @@ pub(crate) unconstrained fn __add<let N: u32>(
 /// Subtracts two `BigNum` values with modular reduction (unconstrained).
 ///
 /// Computes `x + (m - y)` (mod m)
-pub(crate) unconstrained fn __sub<let N: u32>(
+pub unconstrained fn __sub<let N: u32>(
     modulus: [u128; N],
     lhs: [u128; N],
     rhs: [u128; N],
@@ -123,7 +123,7 @@ pub(crate) unconstrained fn __mul_with_quotient<let N: u32, let MOD_BITS: u32>(
 }
 
 /// Multiplies two `BigNum` values with modular reduction (unconstrained).
-pub(crate) unconstrained fn __mul<let N: u32, let MOD_BITS: u32>(
+pub unconstrained fn __mul<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     lhs: [u128; N],
     rhs: [u128; N],
@@ -132,7 +132,7 @@ pub(crate) unconstrained fn __mul<let N: u32, let MOD_BITS: u32>(
 }
 
 /// Squares a `BigNum` value with modular reduction (unconstrained).
-pub(crate) unconstrained fn __sqr<let N: u32, let MOD_BITS: u32>(
+pub unconstrained fn __sqr<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) -> [u128; N] {
@@ -146,7 +146,7 @@ pub(crate) unconstrained fn __sqr<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// For the loop, we are using `MOD_BITS` instead of `__get_msb`
 /// because it is much much cheaper
-pub(crate) unconstrained fn __pow<let N: u32, let MOD_BITS: u32>(
+pub unconstrained fn __pow<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
     exponent: [u128; N],
@@ -172,7 +172,7 @@ pub(crate) unconstrained fn __pow<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// The input value must be nonzero and modulus has to be prime
 /// No explicit assertion is made, as this condition is validated during evaluation
-pub(crate) unconstrained fn __invmod<let N: u32, let MOD_BITS: u32>(
+pub unconstrained fn __invmod<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     val: [u128; N],
 ) -> [u128; N] {
@@ -188,7 +188,7 @@ pub(crate) unconstrained fn __invmod<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// The divisor must be nonzero
 /// No explicit assertion is made, as this condition is validated during evaluation
-pub(crate) unconstrained fn __div<let N: u32, let MOD_BITS: u32>(
+pub unconstrained fn __div<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     numerator: [u128; N],
     divisor: [u128; N],
@@ -207,7 +207,7 @@ pub(crate) unconstrained fn __div<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// The divisor must be nonzero
 /// No explicit assertion is made, as this condition is validated during evaluation
-pub(crate) unconstrained fn __udiv_mod<let N: u32>(
+pub unconstrained fn __udiv_mod<let N: u32>(
     numerator: [u128; N],
     divisor: [u128; N],
 ) -> ([u128; N], [u128; N]) {
@@ -345,7 +345,7 @@ pub(crate) unconstrained fn batch_invert_slice<let N: u32, let MOD_BITS: u32>(
 }
 
 /// Compute a modular square root in a prime field (unconstrained)
-pub(crate) unconstrained fn __sqrt<let N: u32, let MOD_BITS: u32>(
+pub unconstrained fn __sqrt<let N: u32, let MOD_BITS: u32>(
     params: BigNumParams<N, MOD_BITS>,
     input: [u128; N],
 ) -> std::option::Option<[u128; N]> {

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -10,7 +10,7 @@ pub mod fields;
 pub mod params;
 
 // Free functions and other utils, called by the BigNum and RuntimeBigNum structs
-pub(crate) mod fns;
+pub mod fns;
 pub(crate) mod utils;
 
 mod benchmarks;


### PR DESCRIPTION
# Description

## Problem\*

context: 
https://aztecprotocol.slack.com/archives/C070W882XTL/p1769009684813229
https://aztecprotocol.slack.com/archives/C04QF64EDNV/p1769017827916589

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
