### PR TITLE
fix!: address audit issues

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  MINIMUM_NOIR_VERSION: nightly-2026-04-08
+  MINIMUM_NOIR_VERSION: 1.0.0-beta.24
 
 jobs:
   test:
@@ -28,7 +28,7 @@ jobs:
       - name: Install bb
         run: |
           curl -L https://bbup.aztec.network | bash
-          ~/.bb/bbup -v 4.0.0-nightly.20260120
+          ~/.bb/bbup -v 5.0.1
 
       - name: Build Noir benchmark programs
         run: nargo export

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MINIMUM_NOIR_VERSION: nightly-2026-04-08
+  MINIMUM_NOIR_VERSION: 1.0.0-beta.24
 
 jobs:
   noir-version-list:

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ These methods can be used using operators (`+`, `-`, `*`, `/`).
 - `udiv`/`udiv_mod` - Expensive!
 - `umod` - Expensive!
   - Integer modular reduction which uses `udiv`
+- `udiv_unsafe`/`udiv_mod_unsafe`/`umod_unsafe` - Unsafe versions of the above that skip `validate_in_field` on the inputs. Use when both operands are already known to be in canonical form (i.e. in `[0, MOD)`).
 
 `derive_bignum` will also implement conversions from a native `Field` type. For example, if you have a `Field` type `Fq`, you can convert it to your `BigNum` type `MyBigNum` by using the following syntax:
 
@@ -235,6 +236,8 @@ let my_bignum: Fq = Fq::from(a);
 ```
 We also support comparison operators (`==`, `!=`) for `BigNum` types. Equality is tested modulo `modulus`
 And we support (`>`, `>=`, `<`, `<=`) in pure integer sense for `BigNum` types.
+
+> **Important:** Comparison operators (`>`, `>=`, `<`, `<=`) compare values as integers over their limb representation, **not** as field elements. Both operands must be in canonical form (i.e. in `[0, MOD)`). Call `validate_in_field` on each operand before comparing, otherwise non-canonical representations (e.g. `MOD` vs `0`) will produce incorrect results.
 
 
 > **Note:** `div`, `udiv` and `umod` are expensive due to requiring modular exponentiations during witness computation. It is worth modifying witness generation algorithms to minimize the number of modular exponentiations required. (for example, using batch inverses)
@@ -253,28 +256,30 @@ Other constrained functions:
 - `derive_from_seed` - generates a `"random"` bignum value based on an input byte array `[u8; M]` - seed
 
 **Limb access**
-- `from_limbs`, returns a bignum from an array of limbs. **Note:** you should call `.validate_in_range()` on the resulting bignum.
+- `from_limbs`, returns a bignum from an array of limbs. Limbs are automatically range-checked.
+- `from_limbs_unsafe`, same as `from_limbs` but without range-checking. Use for values that intentionally exceed the normal BigNum range.
 - `get_limbs`, returns the limbs of the bignum at index `idx`
-- `set_limb(idx, value)`, sets limb at `idx` to a new value. **Note:** you should call `.validate_in_range()` on the resulting bignum.
+- `set_limb(idx, value)`, sets limb at `idx` to a new value. The new value is automatically range-checked.
+- `set_limb_unsafe(idx, value)`, same as `set_limb` but without range-checking.
 
 **Byte conversions**
-- `from_be_bytes`, returns a bignum from a big-endian byte array
-- `from_le_bytes`, returns a bignum from a little-endian byte array
-- `to_be_bytes`, returns the big-endian byte representation of a bignum
-- `to_le_bytes`, returns the little-endian byte representation of a bignum
+- `from_be_bytes`, returns a bignum from a big-endian byte array. Validates the result is in `[0, MOD)` via `validate_in_field`.
+- `from_le_bytes`, returns a bignum from a little-endian byte array. Validates the result is in `[0, MOD)` via `validate_in_field`.
+- `to_be_bytes`, returns the big-endian byte representation of a bignum. Validates the input is in `[0, MOD)` via `validate_in_field`.
+- `to_le_bytes`, returns the little-endian byte representation of a bignum. Validates the input is in `[0, MOD)` via `validate_in_field`.
+- `from_be_bytes_unsafe`/`from_le_bytes_unsafe`/`to_be_bytes_unsafe`/`to_le_bytes_unsafe` - Unsafe versions of the above that skip `validate_in_field`. Use when the value is already known to be in canonical form (i.e. in `[0, MOD)`).
 
 **Comparison operators**
 - `eq`, also available with operator `==`
 - `assert_is_not_equal`, assert 2 bignums are distinct. **Note:** this is cheaper than `assert(a != b)`
 - `is_zero`, returns a boolean, that is `true` if the bignum value is 0 or `modulus`. **Note:** this is cheaper than `assert(a == bignum::zero())`.
-- `is_zero_integer`, returns a boolean, that is `true` if the bignum value is strictly 0 (all limbs are 0). **Note:** equivalent to `assert(a.get_limbs() == [0; N])` but cheaper.
+- `unsafe_is_zero_integer`, returns a boolean, that is `true` if the bignum value is strictly 0 (all limbs are 0). **Note:** equivalent to `assert(a.get_limbs() == [0; N])` but cheaper.
 - `assert_is_not_zero`, assert that a bignum is not 0 or `modulus`, **Note:** this is cheaper than `assert(!a.is_zero())` or `assert(a != bignum::zero())`.
-- `assert_is_not_zero_integer`, assert that a bignum is not strictly 0 (**all limbs are 0**). **Note:** cheaper than `assert(!a.is_zero_integer())` and `assert(a.get_limbs() != [0; N])`.
+- `unsafe_assert_is_not_zero_integer`, assert that a bignum is not strictly 0 (**all limbs are 0**). **Note:** cheaper than `assert(!a.is_zero_integer())` and `assert(a.get_limbs() != [0; N])`.
 
 **Range operators**
 - `validate_in_range`, validates the bignum doesn't have more bits than `modulus_bits` and each limb is a strict `120-bit` value
-- `validate_in_field` – validates `self <= modulus`.
-  - **Note:** `self == modulus` is allowed (consistent with the rest of the library).
+- `validate_in_field` – validates `self < modulus`.
   - **Note:** `validate_in_range` constraints are *deduplicated* (cached) per value, so calling it multiple times on the same `BigNum` will not add duplicate constraints. `validate_in_field` is *not* deduplicated, so repeated calls will add the check again.
   - **Note:** `validate_in_field` is a stronger assertion than `validate_in_range`
 
@@ -314,7 +319,9 @@ The method `evaluate_quadratic_expression` has the following interface:
 
 `ADD_N` represents the number of `BigNum` objects being added
 
-The flag parameters `lhs_flags, rhs_flags, add_flags` define whether an operand in the expression will be negated. 
+The flag parameters `lhs_flags, rhs_flags, add_flags` define whether an operand in the expression will be negated.
+
+**Parameter limits:** The combination of `NUM_PRODUCTS`, `LHS_N`, and `RHS_N` must be small enough that intermediate product limbs do not exceed 2^{246}. Exceeding this bound breaks the 126-bit range check used internally. The library enforces this at compile time and will reject parameter combinations that could overflow. As a rough guideline, `NUM_PRODUCTS * LHS_N * RHS_N` should stay well below 64 for typical moduli. For example, with `BN254_Fq` (3 limbs, 254-bit modulus), `NUM_PRODUCTS=33` with `LHS_N=RHS_N=1`, or `NUM_PRODUCTS=1` with `LHS_N=RHS_N=6`, will be rejected.
 
 For example, for the earlier example we wanted to calculate `a * b + (c + d) * e + f = g`. To constrain this, we pass `a * b + (c + d) * e + f - g = 0` to `evaluate_quadratic_expression`. The parameters then become:
 - `NUM_PRODUCTS` = 2. The products are `a * b` and `(c + d) * e`
@@ -447,6 +454,14 @@ For example, after cloning and building the tool, for a `modulus` of 1024 bits f
 #### Provide parameters for runtime known modulus
 
 For a modulus that is known at runtime, the needed parameters in `BigNumParams` can be provided as witnesses. In the program, use `RuntimeBigNum`, which only requires the number of limbs and number of bits of modulus at the type definition.  
+
+**Security warning: private modulus**
+
+If the modulus is provided as a **private witness** (not a public input), the prover is free to choose any modulus that fits within `MOD_BITS`. The circuit only checks that arithmetic is internally consistent modulo the provided value - it does not verify *which* modulus was used.
+
+A malicious prover can exploit this by substituting a weak modulus (e.g. a smooth composite number - a product of small primes). Equations that would be hard to solve over the intended modulus become trivial: solve mod each small factor separately, then combine via CRT.
+
+**For cryptographic use cases, the modulus should be a public input or otherwise constrained by the surrounding circuit.** If your application relies on the modulus being a specific value (or having specific properties like primality), you must enforce that yourself - `RuntimeBigNum` will not do it for you.
 
 ```rust
 use dep::bignum::BigNum;

--- a/src/benchmarks/bignum_benchmarks.nr
+++ b/src/benchmarks/bignum_benchmarks.nr
@@ -39,10 +39,10 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
     let derive_from_seed_13_elements_bench_name =
         f"derive_from_seed_13_elements_{module_name}".quoted_contents();
 
+    let evaluate_quadratic_expression_1_element_bench_name =
+        f"evaluate_quadratic_expression_1_element_{module_name}".quoted_contents();
     let evaluate_quadratic_expression_3_elements_bench_name =
         f"evaluate_quadratic_expression_3_elements_{module_name}".quoted_contents();
-    let evaluate_quadratic_expression_12_elements_bench_name =
-        f"evaluate_quadratic_expression_12_elements_{module_name}".quoted_contents();
 
     // Unconstrained methods' benchmarks
     let batch_invert_10_elements_bench_name =
@@ -175,12 +175,17 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
             $BigNum::derive_from_seed(a)
         }
 
+        // `evaluate_quadratic_expression` bounds `NUM_PRODUCTS * LHS_N * RHS_N` so that
+        // the product limbs cannot exceed 2^246 (see `assert_product_limbs_fit_in_246_bits`).
+        // The tightest configuration benchmarked here is U2048 (`N = 18`), which admits at
+        // most 3 sub-products in total, so these benchmarks use single-term linear
+        // combinations and at most 3 products.
         #[export]
-        fn $evaluate_quadratic_expression_3_elements_bench_name(
-            lhs: [[$typ; 3]; 3],
-            lhs_flags: [[bool; 3]; 3],
-            rhs: [[$typ; 3]; 3],
-            rhs_flags: [[bool; 3]; 3],
+        fn $evaluate_quadratic_expression_1_element_bench_name(
+            lhs: [[$typ; 1]; 1],
+            lhs_flags: [[bool; 1]; 1],
+            rhs: [[$typ; 1]; 1],
+            rhs_flags: [[bool; 1]; 1],
             add: [$typ; 3],
             add_flags: [bool; 3],
         ) {
@@ -188,11 +193,11 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
         }
 
         #[export]
-        fn $evaluate_quadratic_expression_12_elements_bench_name(
-            lhs: [[$typ; 3]; 12],
-            lhs_flags: [[bool; 3]; 12],
-            rhs: [[$typ; 3]; 12],
-            rhs_flags: [[bool; 3]; 12],
+        fn $evaluate_quadratic_expression_3_elements_bench_name(
+            lhs: [[$typ; 1]; 3],
+            lhs_flags: [[bool; 1]; 3],
+            rhs: [[$typ; 1]; 3],
+            rhs_flags: [[bool; 1]; 3],
             add: [$typ; 3],
             add_flags: [bool; 3],
         ) {

--- a/src/benchmarks/bignum_benchmarks.nr
+++ b/src/benchmarks/bignum_benchmarks.nr
@@ -70,7 +70,7 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
             -a
         }
 
-        #[export] 
+        #[export]
         fn $sub_bench_name(a: $typ, b: $typ) -> $typ {
             a - b
         }
@@ -85,7 +85,7 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
             a / b
         }
 
-        #[export]  
+        #[export]
         fn $udiv_mod_bench_name(a: $typ, b: $typ) -> ($typ, $typ) {
             $BigNum::udiv_mod(&a, &b)
         }
@@ -112,7 +112,7 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
 
         #[export]
         fn $is_zero_integer_bench_name(a: $typ) -> bool {
-            $BigNum::is_zero_integer(&a)
+            $BigNum::unsafe_is_zero_integer(&a)
         }
 
         #[export]
@@ -127,7 +127,7 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
 
         #[export]
         fn $assert_is_not_zero_integer_bench_name(a: $typ) {
-            $BigNum::assert_is_not_zero_integer(&a)
+            $BigNum::unsafe_assert_is_not_zero_integer(&a)
         }
 
         #[export]
@@ -138,7 +138,7 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
         #[export]
         fn $validate_in_field_bench_name(a: $typ) {
             $BigNum::validate_in_field(&a)
-        }        
+        }
 
         #[export]
         fn $from_field_bench_name(a: Field) -> $typ {
@@ -151,23 +151,23 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
         }
 
         #[export]
-        fn $from_be_bytes_bench_name(a: [u8; ($MOD_BITS+7) / 8]) -> [u128; $N] {
-            crate::fns::serialization::from_be_bytes::<$N, $MOD_BITS>(&a)
+        fn $from_be_bytes_bench_name(a: [u8; ($MOD_BITS + 7) / 8]) -> [u128; $N] {
+            crate::fns::serialization::from_be_bytes_unsafe::<$N, $MOD_BITS>(&a)
         }
 
         #[export]
-        fn $to_be_bytes_bench_name(a: $typ) -> [u8; ($MOD_BITS+7) / 8] {
-            crate::fns::serialization::to_be_bytes::<$N, $MOD_BITS>(&$BigNum::get_limbs(&a))
+        fn $to_be_bytes_bench_name(a: $typ) -> [u8; ($MOD_BITS + 7) / 8] {
+            crate::fns::serialization::to_be_bytes_unsafe::<$N, $MOD_BITS>(&$BigNum::get_limbs(&a))
         }
 
         #[export]
-        fn $from_le_bytes_bench_name(a: [u8; ($MOD_BITS+7) / 8]) -> [u128; $N] {
-            crate::fns::serialization::from_le_bytes::<$N, $MOD_BITS>(&a)
+        fn $from_le_bytes_bench_name(a: [u8; ($MOD_BITS + 7) / 8]) -> [u128; $N] {
+            crate::fns::serialization::from_le_bytes_unsafe::<$N, $MOD_BITS>(&a)
         }
 
         #[export]
-        fn $to_le_bytes_bench_name(a: $typ) -> [u8; ($MOD_BITS+7) / 8] {
-            crate::fns::serialization::to_le_bytes::<$N, $MOD_BITS>(&$BigNum::get_limbs(&a))
+        fn $to_le_bytes_bench_name(a: $typ) -> [u8; ($MOD_BITS + 7) / 8] {
+            crate::fns::serialization::to_le_bytes_unsafe::<$N, $MOD_BITS>(&$BigNum::get_limbs(&a))
         }
 
         #[export]
@@ -200,23 +200,29 @@ comptime fn make_bench(m: Module, params: Quoted) -> Quoted {
         }
 
         #[export]
-        fn $batch_invert_10_elements_bench_name(a: [$typ; 10]) -> [$typ; 10]{
-           // Safety: Benchmarking 
-           unsafe { crate::bignum::batch_invert(a) }                         
+        fn $batch_invert_10_elements_bench_name(a: [$typ; 10]) -> [$typ; 10] {
+            // Safety: Benchmarking
+            unsafe {
+                crate::bignum::batch_invert(a)
+            }
         }
 
         #[export]
-        fn $pow_bench_name(a: $typ, b: $typ) -> $typ{
-           // Safety: Benchmarking 
-           unsafe { $BigNum::__pow(&a, &b) }                         
+        fn $pow_bench_name(a: $typ, b: $typ) -> $typ {
+            // Safety: Benchmarking
+            unsafe {
+                $BigNum::__pow(&a, &b)
+            }
         }
 
         #[export]
         fn $sqrt_bench_name(a: $typ) -> Option<$typ> {
-           // Safety: Benchmarking 
-            unsafe { $BigNum::__sqrt(&a) }
+            // Safety: Benchmarking
+            unsafe {
+                $BigNum::__sqrt(&a)
+            }
         }
-   }
+    }
 }
 
 // the types we will be benchmarking

--- a/src/bignum.nr
+++ b/src/bignum.nr
@@ -75,20 +75,17 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
 
     /// Constructs a BigNum from raw limbs.
     ///
-    /// # Safety
-    /// **FOOTGUN**: The limbs are NOT validated. You MUST call `validate_in_range()` on the
-    /// result if the limbs come from untrusted input, otherwise malicious witnesses could
-    /// bypass range checks.
-    ///
-    /// Each limb should be at most 120 bits, except the top limb which should be at most
-    /// `MOD_BITS - 120 * (N - 1)` bits.
-    ///
-    /// # Example
-    /// ```
-    /// let bn = MyBigNum::from_limbs([1, 0, 0]);
-    /// bn.validate_in_range(); // Always validate untrusted input!
-    /// ```
+    /// Each limb is range-checked automatically: at most 120 bits for non-top limbs,
+    /// and at most `MOD_BITS - 120 * (N - 1)` bits for the top limb.
     fn from_limbs(limbs: [u128; N]) -> Self;
+
+    /// Constructs a BigNum from raw limbs without range-checking.
+    ///
+    /// # Safety
+    /// No range checks are performed on the limbs. The resulting value may not
+    /// represent a valid BigNum. Use for cases where limbs intentionally exceed
+    /// the normal range (e.g. quotients from unconstrained computation).
+    fn from_limbs_unsafe(limbs: [u128; N]) -> Self;
 
     /// Returns the raw limb representation.
     ///
@@ -97,10 +94,15 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
 
     /// Sets a specific limb to a new value.
     ///
-    /// # Safety
-    /// **FOOTGUN**: The new limb value is NOT validated. You MUST call `validate_in_range()`
-    /// after modification if the value comes from untrusted input.
+    /// The new value is range-checked automatically: at most 120 bits for non-top limbs,
+    /// and at most `MOD_BITS - 120 * (N - 1)` bits for the top limb.
     fn set_limb(self: &mut Self, idx: u32, value: u128);
+
+    /// Sets a specific limb to a new value without range-checking.
+    ///
+    /// # Safety
+    /// No range check is performed on the new value.
+    fn set_limb_unsafe(self: &mut Self, idx: u32, value: u128);
 
     /// Returns the limb at the given index.
     fn get_limb(&self, idx: u32) -> u128;
@@ -125,6 +127,7 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     unconstrained fn __derive_from_seed<let SeedBytes: u32>(seed: [u8; SeedBytes]) -> Self;
 
     /// Constructs a BigNum from big-endian bytes.
+    /// Validates that the result is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`.
     ///
     /// The byte array length must be exactly `(MOD_BITS + 7) / 8`.
     ///
@@ -132,10 +135,29 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// Panics if the value represented by the bytes is >= 2^MOD_BITS.
     fn from_be_bytes(x: [u8; (MOD_BITS + 7) / 8]) -> Self;
 
+    /// Constructs a BigNum from big-endian bytes without canonical validation.
+    ///
+    /// The byte array length must be exactly `(MOD_BITS + 7) / 8`.
+    ///
+    /// # Panics
+    /// Panics if the value represented by the bytes is >= 2^MOD_BITS.
+    ///
+    /// # Safety
+    /// Only enforces that the value is < 2^MOD_BITS. Does **not** enforce `< MOD`.
+    fn from_be_bytes_unsafe(x: [u8; (MOD_BITS + 7) / 8]) -> Self;
+
     /// Converts to big-endian byte representation.
+    /// Validates that `self` is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`.
     fn to_be_bytes(&self) -> [u8; (MOD_BITS + 7) / 8];
 
+    /// Converts to big-endian byte representation without canonical validation.
+    ///
+    /// # Safety
+    /// Does not enforce that `self` is in canonical form.
+    fn to_be_bytes_unsafe(&self) -> [u8; (MOD_BITS + 7) / 8];
+
     /// Constructs a BigNum from little-endian bytes.
+    /// Validates that the result is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`.
     ///
     /// The byte array length must be exactly `(MOD_BITS + 7) / 8`.
     ///
@@ -143,8 +165,26 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// Panics if the value represented by the bytes is >= 2^MOD_BITS.
     fn from_le_bytes(x: [u8; (MOD_BITS + 7) / 8]) -> Self;
 
+    /// Constructs a BigNum from little-endian bytes without canonical validation.
+    ///
+    /// The byte array length must be exactly `(MOD_BITS + 7) / 8`.
+    ///
+    /// # Panics
+    /// Panics if the value represented by the bytes is >= 2^MOD_BITS.
+    ///
+    /// # Safety
+    /// Only enforces that the value is < 2^MOD_BITS. Does **not** enforce `< MOD`.
+    fn from_le_bytes_unsafe(x: [u8; (MOD_BITS + 7) / 8]) -> Self;
+
     /// Converts to little-endian byte representation.
+    /// Validates that `self` is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`.
     fn to_le_bytes(&self) -> [u8; (MOD_BITS + 7) / 8];
+
+    /// Converts to little-endian byte representation without canonical validation.
+    ///
+    /// # Safety
+    /// Does not enforce that `self` is in canonical form.
+    fn to_le_bytes_unsafe(&self) -> [u8; (MOD_BITS + 7) / 8];
 
     /// Unconstrained equality check.
     ///
@@ -167,9 +207,6 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     unconstrained fn __is_zero(&self) -> bool;
 
     /// Unconstrained negation: computes `-self (mod MOD)`.
-    ///
-    /// # Note
-    /// When `self` is zero, this returns the modulus (which is equivalent to zero mod MOD).
     ///
     /// # Safety
     /// No constraints are generated. Constrain the result using `evaluate_quadratic_expression`.
@@ -199,10 +236,12 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// No constraints are generated. Constrain the result using `evaluate_quadratic_expression`.
     unconstrained fn __sqr(&self) -> Self;
 
-    /// Unconstrained modular division: computes `self * other^{-1} (mod MOD)`.
+    /// Unconstrained modular division: computes `self * other^{-1} (mod MOD)`
+    /// when `MOD` is prime (`params.has_multiplicative_inverse == true`)
+    ///
+    /// Unconstrained unsigned Integer division: computes `floor(self / other)` otherwise
     ///
     /// # Requirements
-    /// - `MOD` must be prime (`params.has_multiplicative_inverse == true`)
     /// - `other` must not be zero
     ///
     /// # Performance Warning
@@ -291,7 +330,7 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// # Note
     /// Unlike `is_zero()`, this returns `false` for the modulus value even though
     /// `modulus == 0 (mod MOD)`.
-    fn is_zero_integer(&self) -> bool;
+    fn unsafe_is_zero_integer(&self) -> bool;
 
     /// Asserts that `self != 0 (mod MOD)`.
     ///
@@ -306,7 +345,7 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     ///
     /// # Performance Note
     /// Cheaper than `assert(!self.is_zero_integer())`.
-    fn assert_is_not_zero_integer(&self);
+    fn unsafe_assert_is_not_zero_integer(&self);
 
     /// Validates that each limb is properly range-constrained.
     ///
@@ -325,11 +364,9 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// This does NOT guarantee `self < MOD`. Use `validate_in_field()` for that.
     fn validate_in_range(&self);
 
-    /// Validates that `self <= MOD`.
+    /// Validates that `self < MOD`.
     ///
     /// # Note
-    /// - This allows `self == MOD` (which equals 0 in modular arithmetic), consistent with
-    ///   the library's treatment of the modulus as a valid representation of zero.
     /// - This is a STRONGER check than `validate_in_range()`.
     /// - Unlike `validate_in_range()`, this check is NOT deduplicated. Repeated calls will
     ///   add redundant constraints.
@@ -356,6 +393,12 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// This is INTEGER division. For modular division on prime fields, use the `/` operator.
     fn udiv_mod(&self, divisor: &Self) -> (Self, Self);
 
+    /// Unsafe version of `udiv_mod`. Does not call `validate_in_field` on the inputs.
+    ///
+    /// # Safety
+    /// Both operands **must** already be in canonical form (i.e. in `[0, MOD)`).
+    fn udiv_mod_unsafe(&self, divisor: &Self) -> (Self, Self);
+
     /// Constrained integer division: returns `floor(self / divisor)`.
     ///
     /// # Performance Warning
@@ -365,6 +408,12 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// This is INTEGER division, not modular. The remainder is discarded.
     fn udiv(&self, divisor: &Self) -> Self;
 
+    /// Unsafe version of `udiv`. Does not call `validate_in_field` on the inputs.
+    ///
+    /// # Safety
+    /// Both operands **must** already be in canonical form (i.e. in `[0, MOD)`).
+    fn udiv_unsafe(&self, divisor: &Self) -> Self;
+
     /// Constrained integer modulo: returns `self % divisor`.
     ///
     /// # Performance Warning
@@ -373,6 +422,12 @@ pub trait BigNum: Neg + Add + Sub + Mul + Div + Eq {
     /// # Note
     /// This is INTEGER modulo. The result is the remainder after integer division.
     fn umod(&self, divisor: &Self) -> Self;
+
+    /// Unsafe version of `umod`. Does not call `validate_in_field` on the inputs.
+    ///
+    /// # Safety
+    /// Both operands **must** already be in canonical form (i.e. in `[0, MOD)`).
+    fn umod_unsafe(&self, divisor: &Self) -> Self;
 }
 
 // We need macros that implement the BigNum, Default, From, Neg, Add, Sub, Mul, Div, Eq, Ord traits for each bignum type
@@ -410,8 +465,13 @@ pub comptime fn derive_bignum(
                 Self {limbs: [0; $N]}
             }
 
-            /// Note: You have to properly constrain the limbs prior calling this method
             fn from_limbs(limbs: [u128; $N]) -> Self {
+                let res = Self { limbs };
+                res.validate_in_range();
+                res
+            }
+
+            fn from_limbs_unsafe(limbs: [u128; $N]) -> Self {
                 Self { limbs }
             }
 
@@ -419,8 +479,16 @@ pub comptime fn derive_bignum(
                 self.limbs
             }
 
-            /// Note: You have to properly constrain the limb prior calling this method
             fn set_limb(self: &mut Self, idx: u32, value: u128) {
+                if idx != ($N - 1){
+                    (value as Field).assert_max_bit_size::<120>();
+                } else {
+                    (value as Field).assert_max_bit_size::<$MOD_BITS - 120 * ($N - 1)>();
+                }
+                self.limbs[idx] = value;
+            }
+
+            fn set_limb_unsafe(self: &mut Self, idx: u32, value: u128) {
                 self.limbs[idx] = value;
             }
 
@@ -449,19 +517,39 @@ pub comptime fn derive_bignum(
             }
 
             fn from_be_bytes(x: [u8; ($MOD_BITS + 7) / 8]) -> Self {
-                Self { limbs: $crate::internal::from_be_bytes::<$N, $MOD_BITS>(&x) }
+                let params = Self::params();
+                Self { limbs: $crate::internal::from_be_bytes::<$N, $MOD_BITS>(&params, &x) }
+            }
+
+            fn from_be_bytes_unsafe(x: [u8; ($MOD_BITS + 7) / 8]) -> Self {
+                Self { limbs: $crate::internal::from_be_bytes_unsafe::<$N, $MOD_BITS>(&x) }
             }
 
             fn to_be_bytes(&self) -> [u8; ($MOD_BITS + 7) / 8] {
-                $crate::internal::to_be_bytes::<$N, $MOD_BITS>(&self.limbs)
+                let params = Self::params();
+                $crate::internal::to_be_bytes::<$N, $MOD_BITS>(&params, &self.limbs)
+            }
+
+            fn to_be_bytes_unsafe(&self) -> [u8; ($MOD_BITS + 7) / 8] {
+                $crate::internal::to_be_bytes_unsafe::<$N, $MOD_BITS>(&self.limbs)
             }
 
             fn from_le_bytes(x: [u8; ($MOD_BITS + 7) / 8]) -> Self {
-                Self { limbs: $crate::internal::from_le_bytes::<$N, $MOD_BITS>(&x) }
+                let params = Self::params();
+                Self { limbs: $crate::internal::from_le_bytes::<$N, $MOD_BITS>(&params, &x) }
+            }
+
+            fn from_le_bytes_unsafe(x: [u8; ($MOD_BITS + 7) / 8]) -> Self {
+                Self { limbs: $crate::internal::from_le_bytes_unsafe::<$N, $MOD_BITS>(&x) }
             }
 
             fn to_le_bytes(&self) -> [u8; ($MOD_BITS + 7) / 8] {
-                $crate::internal::to_le_bytes::<$N, $MOD_BITS>(&self.limbs)
+                let params = Self::params();
+                $crate::internal::to_le_bytes::<$N, $MOD_BITS>(&params, &self.limbs)
+            }
+
+            fn to_le_bytes_unsafe(&self) -> [u8; ($MOD_BITS + 7) / 8] {
+                $crate::internal::to_le_bytes_unsafe::<$N, $MOD_BITS>(&self.limbs)
             }
 
             unconstrained fn __eq(&self, other: &Self) -> bool {
@@ -553,7 +641,7 @@ pub comptime fn derive_bignum(
 
             fn validate_in_range(&self) {
                 let limbs = self.get_limbs();
-                $crate::internal::validate_in_range::<u128, $N, $MOD_BITS>(&limbs);
+                $crate::internal::validate_in_range::<$N, $MOD_BITS>(&limbs);
             }
 
             fn sqr(&self) -> Self {
@@ -562,22 +650,44 @@ pub comptime fn derive_bignum(
             }
 
             fn udiv_mod(&self, divisor: &Self) -> (Self, Self) {
+                let params = Self::params();
                 let self_limbs = self.get_limbs();
                 let divisor_limbs = divisor.get_limbs();
-                let (q, r) = $crate::internal::udiv_mod::<$N, $MOD_BITS>(&self_limbs, &divisor_limbs);
+                let (q, r) = $crate::internal::udiv_mod::<$N, $MOD_BITS>(&params, &self_limbs, &divisor_limbs);
                 (Self {limbs: q}, Self {limbs: r})
             }
 
             fn udiv(&self, divisor: &Self) -> Self {
+                let params = Self::params();
                 let self_limbs = self.get_limbs();
                 let divisor_limbs = divisor.get_limbs();
-                Self {limbs: $crate::internal::udiv::<$N, $MOD_BITS>(&self_limbs, &divisor_limbs)}
+                Self {limbs: $crate::internal::udiv::<$N, $MOD_BITS>(&params, &self_limbs, &divisor_limbs)}
+            }
+
+            fn udiv_unsafe(&self, divisor: &Self) -> Self {
+                let self_limbs = self.get_limbs();
+                let divisor_limbs = divisor.get_limbs();
+                Self {limbs: $crate::internal::udiv_unsafe::<$N, $MOD_BITS>(&self_limbs, &divisor_limbs)}
             }
 
             fn umod(&self, divisor: &Self) -> Self {
+                let params = Self::params();
                 let self_limbs = self.get_limbs();
                 let divisor_limbs = divisor.get_limbs();
-                Self {limbs: $crate::internal::umod::<$N, $MOD_BITS>(&self_limbs, &divisor_limbs)}
+                Self {limbs: $crate::internal::umod::<$N, $MOD_BITS>(&params, &self_limbs, &divisor_limbs)}
+            }
+
+            fn umod_unsafe(&self, divisor: &Self) -> Self {
+                let self_limbs = self.get_limbs();
+                let divisor_limbs = divisor.get_limbs();
+                Self {limbs: $crate::internal::umod_unsafe::<$N, $MOD_BITS>(&self_limbs, &divisor_limbs)}
+            }
+
+            fn udiv_mod_unsafe(&self, divisor: &Self) -> (Self, Self) {
+                let self_limbs = self.get_limbs();
+                let divisor_limbs = divisor.get_limbs();
+                let (q, r) = $crate::internal::udiv_mod_unsafe::<$N, $MOD_BITS>(&self_limbs, &divisor_limbs);
+                (Self {limbs: q}, Self {limbs: r})
             }
 
             fn is_zero(&self) -> bool {
@@ -586,9 +696,9 @@ pub comptime fn derive_bignum(
                 $crate::internal::is_zero::<$N, $MOD_BITS>(&params, &limbs)
             }
 
-            fn is_zero_integer(&self) -> bool {
+            fn unsafe_is_zero_integer(&self) -> bool {
                 let limbs = self.get_limbs();
-                $crate::internal::is_zero_integer::<u128,$N>(&limbs)
+                $crate::internal::is_zero_integer::<$N>(&limbs)
             }
 
             fn assert_is_not_zero(&self) {
@@ -597,7 +707,7 @@ pub comptime fn derive_bignum(
                 $crate::internal::assert_is_not_zero::<$N, $MOD_BITS>(&params, &limbs);
             }
 
-            fn assert_is_not_zero_integer(&self) {
+            fn unsafe_assert_is_not_zero_integer(&self) {
                 let limbs = self.get_limbs();
                 $crate::internal::assert_is_not_zero_integer(&limbs);
             }
@@ -645,7 +755,7 @@ pub comptime fn derive_bignum(
                 if $params.has_multiplicative_inverse {
                     $typ { limbs: $crate::internal::div::<$N, $MOD_BITS>($params, self.limbs, other.limbs) }
                 } else {
-                    $typ { limbs: $crate::internal::udiv::<$N, $MOD_BITS>(&self.limbs, &other.limbs) }
+                    $typ { limbs: $crate::internal::udiv::<$N, $MOD_BITS>(&$params, &self.limbs, &other.limbs) }
                 }
             }
         }
@@ -656,6 +766,14 @@ pub comptime fn derive_bignum(
             }
         }
 
+        /// Integer ordering comparison (`>`, `>=`, `<`, `<=`).
+        ///
+        /// Compares values as integers over their limb representation, **not** modular ordering.
+        ///
+        /// # Safety
+        /// Both operands **must** be in canonical form (i.e. in `[0, MOD)`).
+        /// Call `validate_in_field` on each operand before comparing, otherwise
+        /// non-canonical representations (e.g. `MOD` vs `0`) will produce incorrect results.
         impl std::cmp::Ord for $typ {
             fn cmp(self, other: Self) -> std::cmp::Ordering {
                 $crate::internal::cmp::<$N, $MOD_BITS>(&self.limbs, &other.limbs)
@@ -743,7 +861,7 @@ pub unconstrained fn compute_quadratic_expression<T: BigNum, let LHS_N: u32, let
         &crate::utils::map::map(&linear_terms, |bn: &T| bn.get_limbs()),
         &linear_flags,
     );
-    (T::from_limbs(q_limbs), T::from_limbs(r_limbs))
+    (T::from_limbs_unsafe(q_limbs), T::from_limbs_unsafe(r_limbs))
 }
 
 /// Constrains a quadratic expression to equal zero modulo `MOD`.
@@ -861,7 +979,7 @@ pub unconstrained fn batch_invert<T: BigNum, let M: u32>(x: [T; M]) -> [T; M] {
     assert(params.has_multiplicative_inverse);
     let limb_arr = x.map(|bn: T| bn.get_limbs());
     crate::fns::unconstrained_ops::batch_invert(&params, &limb_arr).map(|limbs| {
-        T::from_limbs(limbs)
+        T::from_limbs_unsafe(limbs)
     })
 }
 
@@ -881,7 +999,7 @@ pub unconstrained fn batch_invert_slice<T: BigNum>(x: [T]) -> [T] {
     let params = T::params();
     assert(params.has_multiplicative_inverse);
     crate::fns::unconstrained_ops::batch_invert_slice(&params, x.map(|bn: T| bn.get_limbs()))
-        .map(|limbs| T::from_limbs(limbs))
+        .map(|limbs| T::from_limbs_unsafe(limbs))
 }
 
 /// Converts a BigNum to a native circuit Field element.

--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -21,7 +21,7 @@ pub(crate) fn limbs_to_field<let N: u32, let MOD_BITS: u32>(
     _params: &BigNumParams<N, MOD_BITS>,
     limbs: &[u128; N],
 ) -> Field {
-    validate_in_range::<u128, N, MOD_BITS>(limbs);
+    validate_in_range::<N, MOD_BITS>(limbs);
     if N > 2 {
         // validate that the `BigNum` is less than the Grumpkin modulus
         let mut grumpkin_modulus: [u128; N] = [0; N];
@@ -46,9 +46,9 @@ pub(crate) fn limbs_to_field<let N: u32, let MOD_BITS: u32>(
 ///
 /// Decomposes the `Field` value into 120-bit limbs
 /// then we have three cases:
-///     - MOD_BITS < 253 (grumpkin_mod_bits - 1): it is enough to call for `validate_in_field`, which is basically `val <= MOD`
-///     - MOD_BITS > 253: we need to verify that the obtained `BigNum` `val < GRUMPKIN_MODULUS`
-///     - MOD_BITS = 253: verify that `val < min(MOD, GRUMPKIN_MODULUS)`
+///     - MOD_BITS < 254 (grumpkin_mod_bits): it is enough to call for `validate_in_field`, which is basically `val < MOD`
+///     - MOD_BITS > 254: we need to verify that the obtained `BigNum` `val < GRUMPKIN_MODULUS`
+///     - MOD_BITS = 254: verify that `val < min(MOD, GRUMPKIN_MODULUS)`
 /// Next we verify that all the limbs are properly ranged
 /// and that the accumulated limbs are equal to the input `Field` value
 pub fn from_field<let N: u32, let MOD_BITS: u32>(
@@ -61,7 +61,7 @@ pub fn from_field<let N: u32, let MOD_BITS: u32>(
 
     if !std::runtime::is_unconstrained() {
         // validate the limbs are in range and the value in total is less than 2^254
-        if MOD_BITS < 253 {
+        if MOD_BITS < 254 {
             // this means that the field modulus is smaller than grumpkin modulus so we have to check if the element fields in the field size
             validate_in_field(_params, &result);
         } else {
@@ -70,21 +70,24 @@ pub fn from_field<let N: u32, let MOD_BITS: u32>(
             grumpkin_modulus[1] = GRUMPKIN_MODULUS[1];
             grumpkin_modulus[2] = GRUMPKIN_MODULUS[2];
 
-            if MOD_BITS > 253 {
+            if MOD_BITS > 254 {
                 // this means that the field modulus is larger than grumpkin modulus so we have to check if the element fields in the field size are less than the grumpkin modulus.
                 // also for correct params N is always larger than 3 here
                 validate_gt::<N, MOD_BITS>(&grumpkin_modulus, &result);
             } else {
-                // this is the tricky part, when MOD_BITS = 253, we have to compare the limbs of the modulus to the grumpkin modulus limbs
-                // any `BigNum` with 253 bits will have 3 limbs
+                // this is the tricky part, when MOD_BITS = 254, we have to compare the limbs of the modulus to the grumpkin modulus limbs
+                // any `BigNum` with 254 bits will have 3 limbs
 
                 // if MOD is less than grumpkin modulus, this will be true
                 let mut mod_lt_grumpkin: bool = false;
+                let mut decided: bool = false;
                 for i in 0..3 {
-                    if !mod_lt_grumpkin & (_params.modulus[2 - i] < grumpkin_modulus[2 - i]) {
-                        mod_lt_grumpkin = true;
+                    if !decided & (_params.modulus[2 - i] != grumpkin_modulus[2 - i]) {
+                        mod_lt_grumpkin = _params.modulus[2 - i] < grumpkin_modulus[2 - i];
+                        decided = true;
                     }
                 }
+
                 let min_modulus: [u128; N] = if mod_lt_grumpkin {
                     _params.modulus
                 } else {
@@ -93,7 +96,7 @@ pub fn from_field<let N: u32, let MOD_BITS: u32>(
                 validate_gt::<N, MOD_BITS>(&min_modulus, &result);
             }
         }
-        validate_in_range::<u128, N, MOD_BITS>(&result);
+        validate_in_range::<N, MOD_BITS>(&result);
 
         // validate the limbs sum up to the field value
         let field_val: Field = if N < 2 {
@@ -116,6 +119,9 @@ pub fn from_field<let N: u32, let MOD_BITS: u32>(
 /// This function *should* produce a uniformly randomly distributed value modulo `MOD`
 ///
 ///  First we take the seed and pack it's 31-byte chunks into `Field`s
+///  A length separator (SeedBytes) is appended to the seed before hashing
+///  to prevent collisions between seeds that differ only in leading zeros.
+///
 ///  We use a hash function that can be modelled as a random oracle
 ///  We hash the packed seed using Poseidon2 to produce `MOD_BITS * 2` bits of entropy
 ///
@@ -138,14 +144,20 @@ pub fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32>(
     // For the seed of length M, we construct a rolling_hash_field of size ceil(M / 31).
     // i.e.  31 bytes per Field
     // NOTE: the Fields produced are 248 bits in size
-    let mut rolling_hash_fields: [Field; (SeedBytes + 30) / 31] = [0; (SeedBytes + 30) / 31];
+
+    assert(SeedBytes < 256, "derive_from_seed: seed is too big");
+    let mut rolling_hash_fields: [Field; (SeedBytes + 31) / 31] = [0; (SeedBytes + 31) / 31];
     let mut seed_ptr: u32 = 0;
-    for i in 0..(SeedBytes + 30) / 31 {
+    for i in 0..(SeedBytes + 31) / 31 {
         let mut packed: Field = 0;
         for _ in 0..31 {
             if (seed_ptr < SeedBytes) {
                 packed *= 256;
                 packed += seed[seed_ptr] as Field;
+                seed_ptr += 1;
+            } else if seed_ptr == SeedBytes {
+                packed *= 256;
+                packed += SeedBytes as Field;
                 seed_ptr += 1;
             }
         }
@@ -153,7 +165,7 @@ pub fn derive_from_seed<let N: u32, let MOD_BITS: u32, let SeedBytes: u32>(
     }
 
     let compressed: Field =
-        poseidon::poseidon2::Poseidon2::hash(rolling_hash_fields, (SeedBytes + 30) / 31);
+        poseidon::poseidon2::Poseidon2::hash(rolling_hash_fields, (SeedBytes + 31) / 31);
     let mut rolling_hash: [Field; 2] = [compressed, 0];
 
     // 120 bit limb has 15 bytes in it
@@ -319,7 +331,7 @@ pub fn assert_is_not_equal<let N: u32, let MOD_BITS: u32>(
 /// This is due to subtract constrains the diff value to be < 2^MOD_BITS, not < `MOD`
 ///
 /// ## Soundness
-/// This function is conditionally *sound*. See `sub` for details
+/// This function is *sound*. See `sub` for details
 ///
 /// ## Completeness
 /// This function is *complete*. An honest prover will always be able to execute it.
@@ -360,10 +372,7 @@ pub fn eq<let N: u32, let MOD_BITS: u32>(
 /// ## Note
 /// This is slightly cheaper than doing `val != [0; N]`, as we avoid
 /// creating per-limb boolean equalities and chaining them with `and`s.
-pub fn assert_is_not_zero_integer<T, let N: u32>(val: &[T; N])
-where
-    T: Into<Field>,
-{
+pub fn assert_is_not_zero_integer<let N: u32>(val: &[u128; N]) {
     assert(!is_zero_integer(val), "assert_is_not_zero_integer fail");
 }
 
@@ -377,10 +386,7 @@ where
 /// ## Note
 /// This is slightly cheaper than testing `val == [0; N]`, as we avoid
 /// creating per-limb boolean equalities and chaining them with `and`s.
-pub fn is_zero_integer<T, let N: u32>(val: &[T; N]) -> bool
-where
-    T: Into<Field>,
-{
+pub fn is_zero_integer<let N: u32>(val: &[u128; N]) -> bool {
     let mut limb_sum: Field = 0;
     for i in 0..N {
         limb_sum += val[i].into();
@@ -432,15 +438,12 @@ pub fn is_zero<let N: u32, let MOD_BITS: u32>(
 /// It is nicely decomposed into
 /// 14-bit range check and 3-bit range check - much much cheaper, since 14-bit range checks
 /// are already pretty common for 120-bit range checks
-pub fn validate_in_range<T, let N: u32, let MOD_BITS: u32>(limbs: &[T; N])
-where
-    T: Into<Field>,
-{
+pub fn validate_in_range<let N: u32, let MOD_BITS: u32>(limbs: &[u128; N]) {
     for i in 0..(N - 1) {
-        limbs[i].into().assert_max_bit_size::<120>();
+        (limbs[i] as Field).assert_max_bit_size::<120>();
     }
 
-    limbs[N - 1].into().assert_max_bit_size::<MOD_BITS - ((N - 1) * 120)>();
+    (limbs[N - 1] as Field).assert_max_bit_size::<MOD_BITS - ((N - 1) * 120)>();
 }
 
 /// Validate quotient produced from `evaluate_quadratic_expression` is well-formed
@@ -465,7 +468,7 @@ pub(crate) fn validate_quotient_in_range<let N: u32, let MOD_BITS: u32>(limbs: &
 /// then constrain `result` to be a valid `BigNum` value.
 ///
 /// ## Completeness
-/// This function is complete and will work only if `lhs > rhs` over the integers.
+/// This function is complete: it will succeed for any `lhs > rhs` over the integers.
 ///
 /// ## Soundness
 /// This function is sound:
@@ -483,6 +486,10 @@ pub(crate) fn validate_quotient_in_range<let N: u32, let MOD_BITS: u32>(limbs: &
 /// `assert_is_not_zero_integer(result)` is crucial. Without it, we could always provide
 /// two identical inputs `x`, `x` and set `borrow_flags = [false; N]`,
 /// which would satisfy the limb constraints.
+///
+/// Since this is an integer comparison, you should validate_in_field the lhs when needed
+/// to avoid accepting values that are not in canonical form (i.e. >= MOD).
+/// The rhs does not need validation: since lhs > rhs and lhs < MOD, it follows that rhs < MOD.
 pub(crate) fn validate_gt<let N: u32, let MOD_BITS: u32>(lhs: &[u128; N], rhs: &[u128; N]) {
     // Safety: borrow_flags are constrained by `assert_sub_no_overflow`:
     // - incorrect flags cause the computed result to fail 128-bit range checks
@@ -535,7 +542,7 @@ fn assert_sub_no_overflow<let N: u32, let MOD_BITS: u32>(
     result[N - 1] = limb_last as u128;
 
     // Validate that the result is a valid BigNum value (120-bit limbs, TOP_LIMB_BITS for last)
-    validate_in_range::<u128, N, MOD_BITS>(&result);
+    validate_in_range::<N, MOD_BITS>(&result);
 
     result
 }
@@ -589,7 +596,7 @@ fn compute_sub_result<let N: u32, let MOD_BITS: u32>(
     result[N - 1] = limb_last as u128;
 
     // Validate that the result is a valid BigNum value (120-bit limbs, TOP_LIMB_BITS for last)
-    validate_in_range::<u128, N, MOD_BITS>(&result);
+    validate_in_range::<N, MOD_BITS>(&result);
 
     result
 }
@@ -643,53 +650,28 @@ fn compute_add_result<let N: u32, let MOD_BITS: u32>(
     result[N - 1] = limb_last as u128;
 
     // Validate that the result is a valid BigNum value (120-bit limbs, TOP_LIMB_BITS for last)
-    validate_in_range::<u128, N, MOD_BITS>(&result);
+    validate_in_range::<N, MOD_BITS>(&result);
 
     result
 }
 
-/// Validate that `val` <= `MOD`
-///
-/// Compute `result = MOD - val` along with `borrow_flags`,
-/// then constrain `result` to be a valid `BigNum` value.
-///
-/// Basically the same as `validate_gt` but we compute the result on the fly
-/// It is just a bit more optimized as we expect each `BigNum` value to be \leq `MOD`
-///
-/// ## Note
-/// In contrast to `validate_gt`, we allow the value to be `MOD`
-/// Since it is consistent with the rest of the library
+/// Validate that `val` < `MOD`
 pub fn validate_in_field<let N: u32, let MOD_BITS: u32>(
     params: &BigNumParams<N, MOD_BITS>,
     val: &[u128; N],
 ) {
-    let modulus: [u128; N] = params.modulus;
-
-    // Safety: borrow_flags are constrained by the `validate_in_range` check on `p_minus_self`:
-    // - incorrect flags cause `p_minus_self` limbs to overflow Field, failing range checks
-    // - if val > modulus, the subtraction overflows and fails the range check
-    let borrow_flags: [bool; (N - 1)] = unsafe { compute_borrow_flags(&modulus, val) };
-
-    let mut p_minus_self: [Field; N] = [0; N];
-    p_minus_self[0] = (modulus[0] as Field) - (val[0] as Field)
-        + (borrow_flags[0] as Field) * (TWO_POW_120 as Field);
-    for i in 1..N - 1 {
-        p_minus_self[i] = (modulus[i] as Field) - (val[i] as Field)
-            + (borrow_flags[i] as Field) * (TWO_POW_120 as Field)
-            - (borrow_flags[i - 1] as Field);
-    }
-    p_minus_self[N - 1] =
-        (modulus[N - 1] as Field) - (val[N - 1] as Field) - (borrow_flags[N - 2] as Field);
-    validate_in_range::<Field, N, MOD_BITS>(&p_minus_self);
+    validate_gt::<N, MOD_BITS>(&params.modulus, val);
 }
 
-/// Compare two `BigNum` values
+/// Compare two `BigNum` values, returning their `Ordering`.
 ///
-/// Returns `lhs > rhs`
+/// Performs a strict integer comparison over the limb representation,
+/// **not** modular ordering.
 ///
-/// ## Note
-/// This is a strict value comparison over the integers,
-/// the values do not have to be reduced modulo `MOD`.
+/// ## Safety
+/// Both operands **must** be in canonical form (i.e. in `[0, MOD)`).
+/// Call `validate_in_field` on each operand before comparing, otherwise
+/// non-canonical representations (e.g. `MOD` vs `0`) will produce incorrect results.
 pub fn cmp<let N: u32, let MOD_BITS: u32>(lhs: &[u128; N], rhs: &[u128; N]) -> Ordering {
     // Safety: underflow and borrow_flags are constrained by `assert_sub_no_overflow`:
     // - we swap (a, b) based on underflow, then compute a - b
@@ -720,36 +702,9 @@ pub fn cmp<let N: u32, let MOD_BITS: u32>(lhs: &[u128; N], rhs: &[u128; N]) -> O
 
 /// Negate a `BigNum` value
 ///
-/// Computes `result = MOD - val` using limb-wise subtraction with borrow flags,
-/// then constrains:
-///   - all `result` limbs to be a valid `BigNum` value, and
-///   - the subtraction relation with the borrow flags
+/// Computes `result = 0 - val (mod MOD)` using constrained subtraction function
 ///
-/// ## Assumptions
-/// - `val` is a valid `BigNum` in the range `0 <= val <= MOD`.
-///
-/// ## Soundness
-/// This function constrains the following relations:
-///     result[0]     = MOD[0]     - val[0]     + bf[0] * 2^{120}             < 2^{120}
-///     result[i]     = MOD[i]     - val[i]     + bf[i] * 2^{120} - bf[i - 1] < 2^{120},  i = 1..N-2
-///     result[N - 1] = MOD[N - 1] - val[N - 1]                   - bf[N - 2] < 2^{TOP_LIMB_BITS}
-///
-/// If all `MOD` and `val` limbs are valid `BigNum` limbs, these constraints
-/// ensure that:
-///   - the borrow flags `bf[i]` form a valid limb-wise subtraction chain, and
-///   - no underflow can occur in the subtraction `MOD - val`.
-///
-/// ## Completeness
-/// This function is complete for inputs in the range `0 <= val <= MOD`.
-/// If a value `val > MOD` is passed in (while still `< 2^{MOD_BITS}`), the
-/// constraints above will fail, since there is no valid borrow chain making
-/// `MOD - val` a well-formed `BigNum`.
-///
-/// In practice, honest provers should not hit this case: all functions in this
-/// module are expected to return values `< MOD`.
-///
-/// ## Note
-/// This function returns `MOD` when `val` is zero.
+/// All constraints and soundness details are handled inside `sub`.
 pub fn neg<let N: u32, let MOD_BITS: u32>(
     params: &BigNumParams<N, MOD_BITS>,
     val: &[u128; N],
@@ -760,15 +715,7 @@ pub fn neg<let N: u32, let MOD_BITS: u32>(
             __neg(&params.modulus, val)
         }
     } else {
-        let modulus = params.modulus;
-        // Safety: borrow_flags are constrained by `assert_sub_no_overflow`:
-        // - incorrect flags cause computed limbs to fail 128-bit range checks
-        // - if val > modulus, the subtraction overflows and fails range checks
-        // (but val > modulus violates function preconditions)
-        let borrow_flags: [bool; N - 1] = unsafe { compute_borrow_flags(&modulus, val) };
-
-        // Subtract `val` from the modulus to negate.
-        assert_sub_no_overflow::<N, MOD_BITS>(&modulus, val, &borrow_flags)
+        sub(params, &[0; N], val)
     }
 }
 
@@ -854,11 +801,6 @@ pub fn neg<let N: u32, let MOD_BITS: u32>(
 ///   a malicious prover can "hide" an extra `MOD` inside the choice of
 ///   `overflow_modulus`, `bf` and `cf`, so that the circuit is satisfied by a
 ///   witness
-///
-/// Consequently, this function is only *conditionally* sound: we rely on the
-/// out-of-circuit implementation of `compute_add_flags` to provide the honest
-/// `(borrow_flags, carry_flags, overflow_modulus)` witness. Under that
-/// assumption, the constrained `result` matches `lhs + rhs (mod MOD)`.
 ///
 /// ## Completeness
 ///
@@ -977,11 +919,6 @@ pub fn add<let N: u32, let MOD_BITS: u32>(
 ///   within range. In other words, the circuit can be satisfied by a witness
 ///   that does **not** correspond to the unique intended subtraction modulo
 ///   `MOD` for some inputs with `lhs < rhs`.
-///
-/// Consequently, this function is only *conditionally* sound: we rely on the
-/// out-of-circuit implementation of `compute_sub_flags` to provide the honest
-/// `(borrow_flags, carry_flags, underflow_modulus)` witness. Under that
-/// assumption, the constrained `result` matches `lhs - rhs (mod MOD)`.
 ///
 /// ## Completeness
 ///
@@ -1172,16 +1109,46 @@ pub fn div<let N: u32, let MOD_BITS: u32>(
 /// ## Soundness
 /// Soundness reduces to `validate_udiv_mod_expression` for the relation
 ///     quotient * divisor + remainder - numerator = 0,
-/// together with `remainder < divisor` check enforced via `validate_gt`.
+/// together with `remainder < divisor` check enforced via `validate_gt`
+/// and `validate_in_field` for divisor to be strictly less than MOD
 ///
 /// Under these checks, any satisfying assignment corresponds to a valid
 /// integer division `numerator = quotient * divisor + remainder` with
-/// `0 <= remainder < divisor`
+/// `0 <= remainder < divisor < MOD`
+/// `0 <= numerator < MOD`
 ///
 /// ## Note
 /// Enforcing `divisor != 0` is not necessary. `remainder < divisor`
 /// Already enforces this.
 pub fn udiv_mod<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
+    numerator: &[u128; N],
+    divisor: &[u128; N],
+) -> ([u128; N], [u128; N]) {
+    // Safety: We constrain the result of __udiv_mod immediately after
+    let (quotient, remainder): ([u128; N], [u128; N]) = unsafe { __udiv_mod(numerator, divisor) };
+    if !std::runtime::is_unconstrained() {
+        // quotient * divisor + remainder - numerator = 0
+        validate_udiv_mod_expression::<N, MOD_BITS>(numerator, divisor, &quotient, &remainder);
+        // remainder < divisor
+        validate_gt::<N, MOD_BITS>(divisor, &remainder);
+        // divisor is in canonical representation
+        validate_in_field(params, divisor);
+        // numerator is in canonical representation
+        validate_in_field(params, numerator);
+    }
+    (quotient, remainder)
+}
+
+/// Unsafe version of `udiv_mod`.
+///
+/// Does not call `validate_in_field` on the numerator or divisor.
+///
+/// ## Safety
+/// Both `numerator` and `divisor` **must** already be in canonical form (i.e. in `[0, MOD)`).
+/// Use this variant when the inputs have already been validated via `validate_in_field`
+/// (e.g. as outputs of other constrained operations) to avoid redundant checks.
+pub fn udiv_mod_unsafe<let N: u32, let MOD_BITS: u32>(
     numerator: &[u128; N],
     divisor: &[u128; N],
 ) -> ([u128; N], [u128; N]) {
@@ -1196,24 +1163,54 @@ pub fn udiv_mod<let N: u32, let MOD_BITS: u32>(
     (quotient, remainder)
 }
 
-/// Compute the `BigNum` integer division
+/// Compute the `BigNum` integer division.
 ///
 /// Returns `floor(numerator / divisor)`.
 /// All constraints and soundness details are handled inside `udiv_mod`.
 pub fn udiv<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
     numerator: &[u128; N],
     divisor: &[u128; N],
 ) -> [u128; N] {
-    udiv_mod::<N, MOD_BITS>(numerator, divisor).0
+    udiv_mod::<N, MOD_BITS>(params, numerator, divisor).0
 }
 
-/// Compute the `BigNum` remainder
+/// Unsafe version of `udiv`.
+///
+/// Returns `floor(numerator / divisor)`.
+/// All constraints and soundness details are handled inside `udiv_mod_unsafe`.
+///
+/// ## Safety
+/// Both `numerator` and `divisor` **must** already be in canonical form (i.e. in `[0, MOD)`).
+pub fn udiv_unsafe<let N: u32, let MOD_BITS: u32>(
+    numerator: &[u128; N],
+    divisor: &[u128; N],
+) -> [u128; N] {
+    udiv_mod_unsafe::<N, MOD_BITS>(numerator, divisor).0
+}
+
+/// Compute the `BigNum` remainder.
 ///
 /// Returns `numerator % divisor`.
 /// All constraints and soundness details are handled inside `udiv_mod`.
 pub fn umod<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
     numerator: &[u128; N],
     divisor: &[u128; N],
 ) -> [u128; N] {
-    udiv_mod::<N, MOD_BITS>(numerator, divisor).1
+    udiv_mod::<N, MOD_BITS>(params, numerator, divisor).1
+}
+
+/// Unsafe version of `umod`.
+///
+/// Returns `numerator % divisor`.
+/// All constraints and soundness details are handled inside `udiv_mod_unsafe`.
+///
+/// ## Safety
+/// Both `numerator` and `divisor` **must** already be in canonical form (i.e. in `[0, MOD)`).
+pub fn umod_unsafe<let N: u32, let MOD_BITS: u32>(
+    numerator: &[u128; N],
+    divisor: &[u128; N],
+) -> [u128; N] {
+    udiv_mod_unsafe::<N, MOD_BITS>(numerator, divisor).1
 }

--- a/src/fns/expressions.nr
+++ b/src/fns/expressions.nr
@@ -256,6 +256,9 @@ pub(crate) unconstrained fn __compute_quadratic_expression<let N: u32, let MOD_B
 /// 1. Negative terms are implemented by adding `double_modulus`
 /// `double_modulus` is chosen so that all limbs except the top one
 /// are > 2^{120}, which prevents underflows in intermediate computations.
+/// However it can cause completeness issues. Refer to the "Note on negation flags"
+/// section of `assert_product_limbs_fit_in_246_bits` and the
+/// `test_evaluate_quadratic_expression_limb_overflow` test.
 ///
 /// 2. For the most significant limb we slightly reduce the padding (to keep the
 /// overall value equal to `2 * MOD`), so in principle there is a narrow edge
@@ -515,6 +518,67 @@ fn validate_expression_is_zero<let N: u32>(mut limbs: [Field; N]) {
     assert(limbs[N - 1] == 0);
 }
 
+/// Completeness check for `evaluate_quadratic_expression`: ensure that each limb
+/// of the convolution product `lhs_linear * rhs_linear` is strictly below `2^{246}`,
+/// so that the 126-bit range check in `validate_expression_is_zero` can succeed for
+/// honest witnesses.
+///
+/// Each input is validated to have limbs `< 2^{120}` (non-top) or `< 2^{TOP_LIMB_BITS}`
+/// (top), where `TOP_LIMB_BITS = MOD_BITS - (N - 1) * 120`. After
+/// `compute_linear_expressions` sums `LHS_N` terms per side, each non-top limb of
+/// `lhs_linear` is at most `LHS_N * (2^{120} - 1)` and the top limb is at most
+/// `LHS_N * (2^{TOP_LIMB_BITS} - 1)`. Similarly for `rhs_linear`.
+///
+/// The product has `2N - 1` limbs. At position `k`, the convolution is
+/// `sum_{i + j = k} lhs_linear[i] * rhs_linear[j]`. The two candidate positions for
+/// the largest value are:
+///
+///   - Position `N - 2`: `N - 1` pairs, all non-top * non-top. Dominates when
+///     `TOP_LIMB_BITS < 120` (the common case).
+///   - Position `N - 1`: `N` pairs, two of which mix a top limb with a non-top limb.
+///     Dominates only when `TOP_LIMB_BITS == 120`.
+///
+/// ## Note on negation flags
+/// When a flag is true the per-term contribution becomes `double_modulus[i] - term[i]`,
+/// which can reach `~3 * 2^{120}` per non-top limb (vs `2^{120} - 1` when unflagged).
+/// The checks below use the unflagged bound; with flags the actual max could be
+/// `~9x` larger. However, flags are per-term (not per-limb), so the relative
+/// ordering of limb positions is preserved: `N - 2` and `N - 1` remain the correct
+/// positions to check.
+///
+/// ## Note on `Field.lt()` precision
+/// These checks use `Field` arithmetic. If the product exceeds the field modulus
+/// `p` (`~2^{254}`), `Field.lt()` could wrap around and give a false pass. This
+/// requires roughly `NUM_PRODUCTS * LHS_N * RHS_N * (N - 1) > 2^{14}`, which is
+/// unrealistic in practice.
+pub(crate) fn assert_product_limbs_fit_in_246_bits<let N: u32, let MOD_BITS: u32, let LHS_N: u32, let RHS_N: u32, let NUM_PRODUCTS: u32>() {
+    let top_limb_bits: u128 = (MOD_BITS - (N - 1) * 120) as u128;
+    let max_non_top_limb: Field = (TWO_POW_120 - 1) as Field;
+    let max_top_limb: Field = ((1u128 << top_limb_bits) - 1) as Field;
+
+    // Over the whole expression, each convolution coefficient is summed `NUM_PRODUCTS`
+    // times, and each pair of linear combinations contributes `LHS_N * RHS_N` sub-products.
+    let num_sub_products_per_limb: Field = NUM_PRODUCTS as Field * LHS_N as Field * RHS_N as Field;
+
+    // Position `N - 1` has `N` pairs: two mix a top limb with a non-top limb,
+    // the remaining `N - 2` are both non-top.
+    let n_minus_1: u32 = N - 1;
+    let max_limb_at_pos_n_minus_1: Field =
+        max_non_top_limb * (2 * max_top_limb + (N - 2) as Field * max_non_top_limb);
+    assert(
+        (num_sub_products_per_limb * max_limb_at_pos_n_minus_1).lt(TWO_POW_246),
+        f"product limbs may exceed 2^246 at limb {n_minus_1}",
+    );
+
+    // Position `N - 2` has `N - 1` pairs, all non-top * non-top.
+    let n_minus_2: u32 = N - 2;
+    let max_limb_at_pos_n_minus_2: Field = (N - 1) as Field * max_non_top_limb * max_non_top_limb;
+    assert(
+        (num_sub_products_per_limb * max_limb_at_pos_n_minus_2).lt(TWO_POW_246),
+        f"product limbs may exceed 2^246 at limb {n_minus_2}",
+    );
+}
+
 /// Constrain a degree-2 `BigNum` expression to be equal to 0 (mod `MOD`)
 ///
 //
@@ -647,16 +711,15 @@ pub(crate) fn evaluate_quadratic_expression<let N: u32, let MOD_BITS: u32, let L
     linear_terms: &[[u128; N]; ADD_N],
     linear_flags: &[bool; ADD_N],
 ) {
-    assert(NUM_PRODUCTS < 64, f"evaluate_quadratic_expression overflow in operands count");
-    // NUM_PRODUCTS < 64 is a light bound that tries to ensure each limb sum < 2^{246} so that the 126-bit bound is valid.
+    assert_product_limbs_fit_in_246_bits::<N, MOD_BITS, LHS_N, RHS_N, NUM_PRODUCTS>();
 
     lhs_terms.for_each(|lhs_limbs: [[u128; N]; LHS_N]| {
-        lhs_limbs.for_each(|term: [u128; N]| validate_in_range::<u128, N, MOD_BITS>(&term))
+        lhs_limbs.for_each(|term: [u128; N]| validate_in_range::<N, MOD_BITS>(&term))
     });
     rhs_terms.for_each(|rhs_limbs: [[u128; N]; RHS_N]| {
-        rhs_limbs.for_each(|term: [u128; N]| validate_in_range::<u128, N, MOD_BITS>(&term))
+        rhs_limbs.for_each(|term: [u128; N]| validate_in_range::<N, MOD_BITS>(&term))
     });
-    linear_terms.for_each(|term: [u128; N]| validate_in_range::<u128, N, MOD_BITS>(&term));
+    linear_terms.for_each(|term: [u128; N]| validate_in_range::<N, MOD_BITS>(&term));
 
     let expression_limbs: [Field; 2 * N - 1] = compute_quadratic_expression_with_modulus::<N, MOD_BITS, LHS_N, RHS_N, NUM_PRODUCTS, ADD_N>(
         params,
@@ -806,10 +869,14 @@ pub(crate) fn validate_udiv_mod_expression<let N: u32, let MOD_BITS: u32>(
     quotient: &[u128; N],
     remainder: &[u128; N],
 ) {
-    validate_in_range::<u128, N, MOD_BITS>(numerator);
-    validate_in_range::<u128, N, MOD_BITS>(divisor);
-    validate_in_range::<u128, N, MOD_BITS>(quotient);
-    validate_in_range::<u128, N, MOD_BITS>(remainder);
+    // The relation `quotient * divisor + remainder - numerator = 0` is a single
+    // degree-2 product with no linear combinations, i.e. NUM_PRODUCTS = LHS_N = RHS_N = 1.
+    assert_product_limbs_fit_in_246_bits::<N, MOD_BITS, 1, 1, 1>();
+
+    validate_in_range::<N, MOD_BITS>(numerator);
+    validate_in_range::<N, MOD_BITS>(divisor);
+    validate_in_range::<N, MOD_BITS>(quotient);
+    validate_in_range::<N, MOD_BITS>(remainder);
 
     let expression_limbs: [Field; N] =
         compute_udiv_mod_expression::<N, MOD_BITS>(numerator, divisor, quotient, remainder);

--- a/src/fns/serialization.nr
+++ b/src/fns/serialization.nr
@@ -1,3 +1,5 @@
+use crate::fns::constrained_ops::validate_in_field;
+use crate::params::BigNumParams;
 use crate::utils::map::invert_array;
 
 // Conversions between big endian and little endian byte arrays and BigNum instances
@@ -7,11 +9,31 @@ use crate::utils::map::invert_array;
 /// Construct a `BigNum` value from a big-endian byte array.
 ///
 /// The input encodes an integer in base 256, which we split into `N` 120-bit limbs.
+/// Validates that the result is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`.
 ///
 /// ## Note
-/// We only enforce that the value is < 2^MOD_BITS. We do not enforce that it is
-/// reduced modulo the field modulus.
+/// Consistency between `N` and `MOD_BITS` is expected:
+///     - `N * 15 >= num_bytes`
+///     - `num_bytes > (N - 1) * 15`
+pub fn from_be_bytes<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
+    x: &[u8; (MOD_BITS + 7) / 8],
+) -> [u128; N] {
+    let result: [u128; N] = from_be_bytes_unsafe::<N, MOD_BITS>(x);
+    validate_in_field(params, &result);
+    result
+}
+
+/// Construct a `BigNum` value from a big-endian byte array without canonical validation.
 ///
+/// The input encodes an integer in base 256, which we split into `N` 120-bit limbs.
+///
+/// ## Safety
+/// Only enforces that the value is < 2^MOD_BITS. Does **not** enforce that it is
+/// reduced modulo the field modulus. Use `from_be_bytes` for canonical validation,
+/// or call `validate_in_field` on the result if needed.
+///
+/// ## Note
 /// Consistency between `N` and `MOD_BITS` is expected:
 ///     - `N * 15 >= num_bytes`
 ///     - `num_bytes > (N - 1) * 15`
@@ -19,8 +41,10 @@ use crate::utils::map::invert_array;
 /// Enforcing range constraints on each limb is crucial for efficiency.
 /// In principle, accumulating `u8` values already bounds the integer,
 /// but relying on Noir to infer a `u128` from a large linear combination
-/// would trigger a very general (and expensive) range checks
-pub fn from_be_bytes<let N: u32, let MOD_BITS: u32>(x: &[u8; (MOD_BITS + 7) / 8]) -> [u128; N] {
+/// would trigger very general (and expensive) range checks.
+pub fn from_be_bytes_unsafe<let N: u32, let MOD_BITS: u32>(
+    x: &[u8; (MOD_BITS + 7) / 8],
+) -> [u128; N] {
     let num_bytes: u32 = (MOD_BITS + 7) / 8;
 
     let mut result: [u128; N] = [0; N];
@@ -58,6 +82,20 @@ pub fn from_be_bytes<let N: u32, let MOD_BITS: u32>(x: &[u8; (MOD_BITS + 7) / 8]
 
 /// Construct a big-endian byte array from a `BigNum` value.
 ///
+/// Validates that the input is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`
+/// before serializing.
+///
+/// The output contains `(MOD_BITS + 7) / 8` bytes.
+pub fn to_be_bytes<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
+    val: &[u128; N],
+) -> [u8; (MOD_BITS + 7) / 8] {
+    validate_in_field(params, val);
+    to_be_bytes_unsafe::<N, MOD_BITS>(val)
+}
+
+/// Construct a big-endian byte array from a `BigNum` value without canonical validation.
+///
 /// The output contains `(MOD_BITS + 7) / 8` bytes. We serialize the most
 /// significant limb first, which may occupy fewer than 15 bytes, followed by
 /// the remaining full 15-byte limbs in big-endian order.
@@ -65,7 +103,14 @@ pub fn from_be_bytes<let N: u32, let MOD_BITS: u32>(x: &[u8; (MOD_BITS + 7) / 8]
 /// Consistency between `N` and `MOD_BITS` is expected:
 ///     - the most significant limb contributes `((MOD_BITS + 7) / 8) - (N - 1) * 15` bytes;
 ///     - all other limbs are serialized as full 15-byte chunks.
-pub fn to_be_bytes<let N: u32, let MOD_BITS: u32>(val: &[u128; N]) -> [u8; (MOD_BITS + 7) / 8] {
+///
+/// ## Safety
+/// Does not enforce the input to be in canonical form. Use `to_be_bytes` for
+/// canonical validation, or call `validate_in_field` on the input before
+/// serializing if a canonical byte representation is required.
+pub fn to_be_bytes_unsafe<let N: u32, let MOD_BITS: u32>(
+    val: &[u128; N],
+) -> [u8; (MOD_BITS + 7) / 8] {
     let mut result: [u8; (MOD_BITS + 7) / 8] = [0; (MOD_BITS + 7) / 8];
 
     let last_limb_num_bytes: u32 = (MOD_BITS + 7) / 8 - (N - 1) * 15;
@@ -89,22 +134,55 @@ pub fn to_be_bytes<let N: u32, let MOD_BITS: u32>(val: &[u128; N]) -> [u8; (MOD_
     result
 }
 
-/// Construct a `BigNum` value from little-endian byte array
+/// Construct a `BigNum` value from a little-endian byte array.
 ///
-/// Reverse an array and apply `from_be_bytes`
+/// Validates that the result is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`.
 ///
-/// See `from_be_bytes` for details
-pub fn from_le_bytes<let N: u32, let MOD_BITS: u32>(x: &[u8; (MOD_BITS + 7) / 8]) -> [u128; N] {
+/// See `from_be_bytes` for details.
+pub fn from_le_bytes<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
+    x: &[u8; (MOD_BITS + 7) / 8],
+) -> [u128; N] {
     let be_x: [u8; (MOD_BITS + 7) / 8] = invert_array(x);
-    from_be_bytes(&be_x)
+    from_be_bytes(params, &be_x)
 }
 
-/// Construct a little-endian byte array from a `BigNum` value
+/// Construct a `BigNum` value from a little-endian byte array without canonical validation.
 ///
-/// Apply `to_be_bytes` and reverse an array
+/// ## Safety
+/// Only enforces that the value is < 2^MOD_BITS. Does **not** enforce that it is
+/// reduced modulo the field modulus. Use `from_le_bytes` for canonical validation,
+/// or call `validate_in_field` on the result if needed.
+pub fn from_le_bytes_unsafe<let N: u32, let MOD_BITS: u32>(
+    x: &[u8; (MOD_BITS + 7) / 8],
+) -> [u128; N] {
+    let be_x: [u8; (MOD_BITS + 7) / 8] = invert_array(x);
+    from_be_bytes_unsafe(&be_x)
+}
+
+/// Construct a little-endian byte array from a `BigNum` value.
 ///
-/// See `to_be_bytes` for details
-pub fn to_le_bytes<let N: u32, let MOD_BITS: u32>(val: &[u128; N]) -> [u8; (MOD_BITS + 7) / 8] {
-    let result_be: [u8; (MOD_BITS + 7) / 8] = to_be_bytes(val);
+/// Validates that the input is in canonical form (i.e. in `[0, MOD)`) via `validate_in_field`
+/// before serializing.
+///
+/// See `to_be_bytes` for details.
+pub fn to_le_bytes<let N: u32, let MOD_BITS: u32>(
+    params: &BigNumParams<N, MOD_BITS>,
+    val: &[u128; N],
+) -> [u8; (MOD_BITS + 7) / 8] {
+    let result_be: [u8; (MOD_BITS + 7) / 8] = to_be_bytes(params, val);
+    invert_array(&result_be)
+}
+
+/// Construct a little-endian byte array from a `BigNum` value without canonical validation.
+///
+/// ## Safety
+/// Does not enforce the input to be in canonical form. Use `to_le_bytes` for
+/// canonical validation, or call `validate_in_field` on the input before
+/// serializing if a canonical byte representation is required.
+pub fn to_le_bytes_unsafe<let N: u32, let MOD_BITS: u32>(
+    val: &[u128; N],
+) -> [u8; (MOD_BITS + 7) / 8] {
+    let result_be: [u8; (MOD_BITS + 7) / 8] = to_be_bytes_unsafe(val);
     invert_array(&result_be)
 }

--- a/src/fns/unconstrained_ops.nr
+++ b/src/fns/unconstrained_ops.nr
@@ -56,12 +56,16 @@ pub(crate) unconstrained fn __gte<let N: u32>(lhs: &[u128; N], rhs: &[u128; N]) 
 
 // ------------------------------ ARITHMETIC FUNCTIONS ------------------------------
 
-/// Negates a `BigNum` value, returning `m - x` (unconstrained)
+/// Negates a `BigNum` value, returning `-x mod (MOD)` (unconstrained)
 ///
 /// ## Note
 /// The input is assumed to be less than modulus
 pub unconstrained fn __neg<let N: u32>(modulus: &[u128; N], limbs: &[u128; N]) -> [u128; N] {
-    __helper_sub(modulus, limbs)
+    if __is_zero(limbs) {
+        *limbs
+    } else {
+        __helper_sub(modulus, limbs)
+    }
 }
 
 /// Adds two `BigNum` values with modular reduction (unconstrained)
@@ -313,14 +317,6 @@ pub unconstrained fn __udiv_mod<let N: u32>(
 ///
 /// ## Note
 /// Zero elements are allowed and are left unchanged in the resulting array
-///
-/// This interacts poorly with `neg(zero)`:
-/// Calling `neg` on `zero` yields `modulus` rather than `0`.
-/// A value in this form will **not** satisfy
-/// the `__is_zero` check and will lead to incorrect results.
-///
-/// This edge case should be rare, but it's worth keeping in mind when
-/// composing operations or debugging unexpected behavior
 pub(crate) unconstrained fn batch_invert<let N: u32, let MOD_BITS: u32, let M: u32>(
     params: &BigNumParams<N, MOD_BITS>,
     vals: &[[u128; N]; M],
@@ -554,26 +550,6 @@ mod test_invmod {
     use crate::fields::bls12_381Fq::BLS12_381_Fq;
     use crate::fields::bn254Fq::BN254_Fq;
     use crate::fields::ed25519Fq::ED25519_Fq;
-
-    /// test inverting neg(zero)
-    unconstrained fn helper_invmod_neg_zero<BN: BigNum>() {
-        let zero: BN = BN::zero();
-        let neg_zero: BN = zero.__neg();
-        let modulus: BN = BN::modulus();
-
-        assert(neg_zero == modulus, "neg(zero) should equal modulus");
-
-        let result: BN = neg_zero.__invmod();
-
-        assert(result.__is_zero(), "invmod(modulus) should return zero");
-    }
-
-    #[test]
-    unconstrained fn test_invmod_neg_zero() {
-        helper_invmod_neg_zero::<BN254_Fq>();
-        helper_invmod_neg_zero::<ED25519_Fq>();
-        helper_invmod_neg_zero::<BLS12_381_Fq>();
-    }
 
     /// test inverting modulus
     unconstrained fn helper_invmod_on_modulus_value<BN: BigNum>() {

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -38,7 +38,10 @@ pub mod internal {
     pub use crate::fns::constrained_ops::sub;
     pub use crate::fns::constrained_ops::udiv;
     pub use crate::fns::constrained_ops::udiv_mod;
+    pub use crate::fns::constrained_ops::udiv_mod_unsafe;
+    pub use crate::fns::constrained_ops::udiv_unsafe;
     pub use crate::fns::constrained_ops::umod;
+    pub use crate::fns::constrained_ops::umod_unsafe;
     pub use crate::fns::constrained_ops::validate_in_field;
     pub use crate::fns::constrained_ops::validate_in_range;
 
@@ -59,9 +62,13 @@ pub mod internal {
 
     // Serialization functions
     pub use crate::fns::serialization::from_be_bytes;
+    pub use crate::fns::serialization::from_be_bytes_unsafe;
     pub use crate::fns::serialization::from_le_bytes;
+    pub use crate::fns::serialization::from_le_bytes_unsafe;
     pub use crate::fns::serialization::to_be_bytes;
+    pub use crate::fns::serialization::to_be_bytes_unsafe;
     pub use crate::fns::serialization::to_le_bytes;
+    pub use crate::fns::serialization::to_le_bytes_unsafe;
 }
 
 // Re-export the main structs so that users don't have to specify the paths

--- a/src/params.nr
+++ b/src/params.nr
@@ -1,4 +1,5 @@
 use crate::constants::TWO_POW_120;
+use crate::fns::constrained_ops::validate_in_range;
 
 pub struct BigNumParams<let N: u32, let MOD_BITS: u32> {
     pub has_multiplicative_inverse: bool,
@@ -16,11 +17,30 @@ pub struct BigNumParams<let N: u32, let MOD_BITS: u32> {
 }
 
 impl<let N: u32, let MOD_BITS: u32> BigNumParams<N, MOD_BITS> {
+    /// Construct a `BigNumParams` with runtime validation.
+    ///
+    /// Validates that `modulus` is exactly `MOD_BITS` bits long:
+    ///   1. Each limb is properly range-constrained (120-bit for non-top, `TOP_LIMB_BITS` for top).
+    ///   2. The top limb has its highest bit set, ensuring the modulus is not shorter than `MOD_BITS`.
+    ///
+    /// `redc_param` is not validated - an incorrect value only affects unconstrained
+    /// witness computation (Barrett reduction), not constrained soundness.
     pub fn new(
         has_multiplicative_inverse: bool,
         modulus: [u128; N],
         redc_param: [u128; N],
     ) -> Self {
+        // Validate that each limb fits in the expected bit width
+        validate_in_range::<N, MOD_BITS>(&modulus);
+
+        // Validate that the top limb is at least 2^(TOP_LIMB_BITS - 1),
+        // i.e. the modulus truly occupies MOD_BITS bits.
+        // This checks: 0 <= top_limb - 2^(TOP_LIMB_BITS - 1) < 2^(TOP_LIMB_BITS - 1)
+        let top_limb: Field = modulus[N - 1] as Field;
+        let top_limb_bits: u128 = (MOD_BITS - (N - 1) * 120) as u128;
+        let min_top_limb: Field = (1u128 << (top_limb_bits - 1)) as Field;
+        (top_limb - min_top_limb).assert_max_bit_size::<MOD_BITS - (N - 1) * 120 - 1>();
+
         Self {
             has_multiplicative_inverse,
             modulus,

--- a/src/runtime_bignum.nr
+++ b/src/runtime_bignum.nr
@@ -5,9 +5,12 @@ use crate::fns::{
     constrained_ops::{
         add, assert_is_not_equal, assert_is_not_zero, assert_is_not_zero_integer, cmp,
         derive_from_seed, div, eq, is_zero, is_zero_integer, mul, neg, sqr, sub, udiv, udiv_mod,
-        umod, validate_in_field, validate_in_range,
+        udiv_mod_unsafe, udiv_unsafe, umod, umod_unsafe, validate_in_field, validate_in_range,
     },
-    serialization::{from_be_bytes, from_le_bytes, to_be_bytes, to_le_bytes},
+    serialization::{
+        from_be_bytes, from_be_bytes_unsafe, from_le_bytes, from_le_bytes_unsafe, to_be_bytes,
+        to_be_bytes_unsafe, to_le_bytes, to_le_bytes_unsafe,
+    },
     unconstrained_ops::{
         __add, __derive_from_seed, __div, __eq, __invmod, __is_zero, __mul, __neg, __pow, __sqr,
         __sqrt, __sub, __udiv_mod,
@@ -54,27 +57,52 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
     }
 
     pub fn from_slice(params: BigNumParams<N, MOD_BITS>, limbs: [u128]) -> Self {
-        Self { limbs: limbs.as_array(), params }
+        let limbs_array: [u128; N] = limbs.as_array();
+        validate_in_range::<N, MOD_BITS>(&limbs_array);
+        Self { limbs: limbs_array, params }
     }
 
     pub fn from_array(params: BigNumParams<N, MOD_BITS>, limbs: [u128; N]) -> Self {
+        validate_in_range::<N, MOD_BITS>(&limbs);
         Self { limbs, params }
     }
 
     pub fn from_be_bytes(params: BigNumParams<N, MOD_BITS>, x: [u8; (MOD_BITS + 7) / 8]) -> Self {
-        Self { limbs: from_be_bytes::<N, MOD_BITS>(&x), params }
+        Self { limbs: from_be_bytes::<N, MOD_BITS>(&params, &x), params }
+    }
+
+    pub fn from_be_bytes_unsafe(
+        params: BigNumParams<N, MOD_BITS>,
+        x: [u8; (MOD_BITS + 7) / 8],
+    ) -> Self {
+        Self { limbs: from_be_bytes_unsafe::<N, MOD_BITS>(&x), params }
     }
 
     pub fn from_le_bytes(params: BigNumParams<N, MOD_BITS>, x: [u8; (MOD_BITS + 7) / 8]) -> Self {
-        Self { limbs: from_le_bytes::<N, MOD_BITS>(&x), params }
+        Self { limbs: from_le_bytes::<N, MOD_BITS>(&params, &x), params }
+    }
+
+    pub fn from_le_bytes_unsafe(
+        params: BigNumParams<N, MOD_BITS>,
+        x: [u8; (MOD_BITS + 7) / 8],
+    ) -> Self {
+        Self { limbs: from_le_bytes_unsafe::<N, MOD_BITS>(&x), params }
     }
 
     pub fn to_be_bytes(&self) -> [u8; (MOD_BITS + 7) / 8] {
-        to_be_bytes::<N, MOD_BITS>(&self.limbs)
+        to_be_bytes::<N, MOD_BITS>(&self.params, &self.limbs)
+    }
+
+    pub fn to_be_bytes_unsafe(&self) -> [u8; (MOD_BITS + 7) / 8] {
+        to_be_bytes_unsafe::<N, MOD_BITS>(&self.limbs)
     }
 
     pub fn to_le_bytes(&self) -> [u8; (MOD_BITS + 7) / 8] {
-        to_le_bytes::<N, MOD_BITS>(&self.limbs)
+        to_le_bytes::<N, MOD_BITS>(&self.params, &self.limbs)
+    }
+
+    pub fn to_le_bytes_unsafe(&self) -> [u8; (MOD_BITS + 7) / 8] {
+        to_le_bytes_unsafe::<N, MOD_BITS>(&self.limbs)
     }
 
     pub fn modulus(&self) -> Self {
@@ -98,8 +126,16 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
         self.limbs[idx]
     }
 
-    /// Note: You have to properly constrain the limbs prior calling this method
     pub fn set_limb(&mut self, idx: u32, value: u128) {
+        if idx != (N - 1) {
+            (value as Field).assert_max_bit_size::<120>();
+        } else {
+            (value as Field).assert_max_bit_size::<MOD_BITS - 120 * (N - 1)>();
+        }
+        self.limbs[idx] = value;
+    }
+
+    pub fn set_limb_unsafe(&mut self, idx: u32, value: u128) {
         self.limbs[idx] = value;
     }
 
@@ -215,7 +251,7 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
     }
 
     pub fn validate_in_range(&self) {
-        validate_in_range::<u128, N, MOD_BITS>(&self.limbs);
+        validate_in_range::<N, MOD_BITS>(&self.limbs);
     }
 
     pub fn assert_is_not_equal(&self, other: &Self) {
@@ -232,20 +268,39 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
     pub fn udiv_mod(&self, divisor: &Self) -> (Self, Self) {
         let params: BigNumParams<N, MOD_BITS> = self.params;
         assert(params == divisor.params);
-        let (q, r) = udiv_mod::<N, MOD_BITS>(&self.limbs, &divisor.limbs);
+        let (q, r) = udiv_mod::<N, MOD_BITS>(&params, &self.limbs, &divisor.limbs);
+        (Self { limbs: q, params }, Self { limbs: r, params })
+    }
+
+    pub fn udiv_mod_unsafe(&self, divisor: &Self) -> (Self, Self) {
+        let params: BigNumParams<N, MOD_BITS> = self.params;
+        assert(params == divisor.params);
+        let (q, r) = udiv_mod_unsafe::<N, MOD_BITS>(&self.limbs, &divisor.limbs);
         (Self { limbs: q, params }, Self { limbs: r, params })
     }
 
     pub fn udiv(&self, divisor: &Self) -> Self {
         let params: BigNumParams<N, MOD_BITS> = self.params;
         assert(params == divisor.params);
-        Self { limbs: udiv::<N, MOD_BITS>(&self.limbs, &divisor.limbs), params }
+        Self { limbs: udiv::<N, MOD_BITS>(&params, &self.limbs, &divisor.limbs), params }
+    }
+
+    pub fn udiv_unsafe(&self, divisor: &Self) -> Self {
+        let params: BigNumParams<N, MOD_BITS> = self.params;
+        assert(params == divisor.params);
+        Self { limbs: udiv_unsafe::<N, MOD_BITS>(&self.limbs, &divisor.limbs), params }
     }
 
     pub fn umod(&self, divisor: &Self) -> Self {
         let params: BigNumParams<N, MOD_BITS> = self.params;
         assert(params == divisor.params);
-        Self { limbs: umod::<N, MOD_BITS>(&self.limbs, &divisor.limbs), params }
+        Self { limbs: umod::<N, MOD_BITS>(&params, &self.limbs, &divisor.limbs), params }
+    }
+
+    pub fn umod_unsafe(&self, divisor: &Self) -> Self {
+        let params: BigNumParams<N, MOD_BITS> = self.params;
+        assert(params == divisor.params);
+        Self { limbs: umod_unsafe::<N, MOD_BITS>(&self.limbs, &divisor.limbs), params }
     }
 
     pub fn is_zero(&self) -> bool {
@@ -253,7 +308,7 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
         is_zero(&params, &self.limbs)
     }
 
-    pub fn is_zero_integer(&self) -> bool {
+    pub fn unsafe_is_zero_integer(&self) -> bool {
         is_zero_integer(&self.limbs)
     }
 
@@ -262,7 +317,7 @@ impl<let N: u32, let MOD_BITS: u32> RuntimeBigNum<N, MOD_BITS> {
         assert_is_not_zero::<N, MOD_BITS>(&params, &self.limbs);
     }
 
-    pub fn assert_is_not_zero_integer(&self) {
+    pub fn unsafe_assert_is_not_zero_integer(&self) {
         assert_is_not_zero_integer(&self.limbs);
     }
 }

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -1,13 +1,15 @@
 use crate::bignum::BigNum;
 use crate::bignum::{compute_quadratic_expression, evaluate_quadratic_expression, to_field};
 use crate::bignum::derive_bignum;
-use crate::fns::constrained_ops::validate_gt;
-use crate::fns::expressions::validate_udiv_mod_expression;
+use crate::constants::{GRUMPKIN_MODULUS, TWO_POW_120, TWO_POW_240};
+use crate::fns::constrained_ops::{from_field, validate_gt};
+use crate::fns::expressions::{assert_product_limbs_fit_in_246_bits, validate_udiv_mod_expression};
 use crate::fns::unconstrained_helpers::{__helper_add, __quadratic_non_residue, __shr};
 use crate::fns::unconstrained_ops::{__easy_sqrt, __tonelli_shanks_sqrt};
 
 use crate::params::BigNumParams;
 
+use crate::fields::bls12_377Fq::BLS12_377_Fq;
 use crate::fields::bls12_377Fr::BLS12_377_Fr;
 use crate::fields::bls12_381Fq::BLS12_381_Fq;
 use crate::fields::bls12_381Fr::BLS12_381_Fr;
@@ -79,7 +81,7 @@ global TEST_2048_PARAMS: BigNumParams<18, 2048> = BigNumParams {
     ],
 };
 
-#[derive_bignum(18, 2048, quote {TEST_2048_PARAMS})]
+#[derive_bignum(18, 2048, quote { TEST_2048_PARAMS })]
 pub struct BN2048 {
     limbs: [u128; 18],
 }
@@ -125,7 +127,7 @@ fn test_sub_underflow_regression() {
     assert(c.get_limbs() == [0, 0, 0]);
 }
 
-#[derive_bignum(2, 224, quote {SecP224r1_PARAMS})]
+#[derive_bignum(2, 224, quote { SecP224r1_PARAMS })]
 struct SecP224r1 {
     limbs: [u128; 2],
 }
@@ -252,6 +254,150 @@ fn test_validate_gt_regression_BN() {
     validate_gt::<3, 254>(&x_limbs, &y_limbs);
 }
 
+// Regression tests for evaluate_quadratic_expression overflow detection.
+// When LHS_N, RHS_N, or NUM_PRODUCTS are too large, `assert_product_limbs_fit_in_246_bits`
+// rejects the expression before any witness values are inspected. Zero inputs are
+// therefore sufficient to exercise the check.
+#[test(should_fail_with = "product limbs may exceed 2^246")]
+fn test_evaluate_quadratic_expression_overflow_num_products_BN() {
+    let zero: BN254_Fq = BigNum::new();
+    // NUM_PRODUCTS=33, LHS_N=1, RHS_N=1
+    // Fails the (N-2)th limb check: 33 * 2 * (2^120-1)^2 > 2^246
+    evaluate_quadratic_expression(
+        [[zero]; 33],
+        [[false]; 33],
+        [[zero]; 33],
+        [[false]; 33],
+        [],
+        [],
+    );
+}
+
+#[test(should_fail_with = "product limbs may exceed 2^246")]
+fn test_evaluate_quadratic_expression_overflow_num_products_BN_2() {
+    let zero: BN254_Fq = BigNum::new();
+    // NUM_PRODUCTS=1, LHS_N=6, RHS_N=6
+    // Fails the (N-2)th limb check: 1 * 6 * 6 * 2 * (2^120-1)^2 > 2^246
+    evaluate_quadratic_expression([[zero; 6]], [[false; 6]], [[zero; 6]], [[false; 6]], [], []);
+}
+
+// The (N-1)th limb bound only dominates when `TOP_LIMB_BITS == 120`, i.e. when
+// `MOD_BITS = N * 120`. None of the shipped `BigNum` types hit that case, so we
+// exercise the check directly via `assert_product_limbs_fit_in_246_bits` with a
+// synthetic `<N, MOD_BITS>` pair.
+//
+// With N=3, MOD_BITS=360, LHS_N=RHS_N=1, NUM_PRODUCTS=22:
+//   - (N-2)th bound: 22 * 2 * (2^120-1)^2 ~ 44 * 2^240 < 2^246  (passes)
+//   - (N-1)th bound: 22 * 3 * (2^120-1)^2 ~ 66 * 2^240 > 2^246  (fails first)
+#[test(should_fail_with = "product limbs may exceed 2^246 at limb 2")]
+fn test_assert_product_limbs_fit_in_246_bits_n_minus_1() {
+    assert_product_limbs_fit_in_246_bits::<3, 360, 1, 1, 22>();
+}
+
+#[test(should_fail_with = "assert_is_not_zero_integer fail")]
+fn test_udiv_mod_non_canonical_regression() {
+    let modulus: U256 = U256::modulus();
+    let one: U256 = U256::one();
+    let (_, _) = one.udiv_mod(&modulus);
+}
+
+// A non-canonical numerator (numerator + MOD) would yield a different quotient.
+// udiv_mod must reject it via validate_in_field.
+#[test(should_fail_with = "assert_max_bit_size")]
+fn test_udiv_mod_non_canonical_numerator() {
+    let modulus_limbs: [u128; 3] = U256::modulus().get_limbs();
+    let five: U256 = U256::from_limbs([5, 0, 0]);
+    let divisor: U256 = U256::from_limbs([10, 0, 0]);
+
+    // Construct MOD + 5 (non-canonical representation of 5)
+    // Safety: test code
+    let non_canonical_limbs: [u128; 3] = unsafe { __helper_add(&five.get_limbs(), &modulus_limbs) };
+    let non_canonical_numerator: U256 = U256::from_limbs(non_canonical_limbs);
+
+    let (_, _) = non_canonical_numerator.udiv_mod(&divisor);
+}
+
+// A non-canonical divisor (divisor + MOD) would yield a different quotient/remainder.
+// udiv_mod must reject it via validate_in_field.
+#[test(should_fail_with = "assert_max_bit_size")]
+fn test_udiv_mod_non_canonical_divisor() {
+    let modulus_limbs: [u128; 3] = U256::modulus().get_limbs();
+    let numerator: U256 = U256::from_limbs([100, 0, 0]);
+    let ten: U256 = U256::from_limbs([10, 0, 0]);
+
+    // Construct MOD + 10 (non-canonical representation of 10)
+    // Safety: test code
+    let non_canonical_limbs: [u128; 3] = unsafe { __helper_add(&ten.get_limbs(), &modulus_limbs) };
+    let non_canonical_divisor: U256 = U256::from_limbs(non_canonical_limbs);
+
+    let (_, _) = numerator.udiv_mod(&non_canonical_divisor);
+}
+
+// udiv_mod_unsafe does not validate inputs, so non-canonical numerator is accepted.
+#[test]
+fn test_udiv_mod_unsafe_non_canonical_numerator() {
+    let modulus_limbs: [u128; 3] = U256::modulus().get_limbs();
+    let five: U256 = U256::from_limbs([5, 0, 0]);
+    let divisor: U256 = U256::from_limbs([10, 0, 0]);
+
+    // Construct MOD + 5 (non-canonical representation of 5)
+    // Safety: test code
+    let non_canonical_limbs: [u128; 3] = unsafe { __helper_add(&five.get_limbs(), &modulus_limbs) };
+    let non_canonical_numerator: U256 = U256::from_limbs(non_canonical_limbs);
+
+    let (_, _) = non_canonical_numerator.udiv_mod_unsafe(&divisor);
+}
+
+// udiv_mod_unsafe does not validate inputs, so non-canonical divisor is accepted.
+#[test]
+fn test_udiv_mod_unsafe_non_canonical_divisor() {
+    let modulus_limbs: [u128; 3] = U256::modulus().get_limbs();
+    let numerator: U256 = U256::from_limbs([100, 0, 0]);
+    let ten: U256 = U256::from_limbs([10, 0, 0]);
+
+    // Construct MOD + 10 (non-canonical representation of 10)
+    // Safety: test code
+    let non_canonical_limbs: [u128; 3] = unsafe { __helper_add(&ten.get_limbs(), &modulus_limbs) };
+    let non_canonical_divisor: U256 = U256::from_limbs(non_canonical_limbs);
+
+    let (_, _) = numerator.udiv_mod_unsafe(&non_canonical_divisor);
+}
+
+#[test(should_fail_with = "call to assert_max_bit_size")]
+fn test_from_field_regression() {
+    // Smaller than Grumpkin modulus
+    let modulus: [u128; 3] = [GRUMPKIN_MODULUS[0] - 10, GRUMPKIN_MODULUS[1], GRUMPKIN_MODULUS[2]];
+    let params: BigNumParams<3, 254> = BigNumParams::new(false, modulus, [0 as u128; 3]);
+    let value: Field = ((modulus[0] + 5) as Field)
+        + (modulus[1] as Field) * (TWO_POW_120 as Field)
+        + (modulus[2] as Field) * TWO_POW_240;
+    let _: [u128; 3] = from_field(&params, value);
+}
+
+// ------------------------------ POSSIBLE COMPLETENESS ISSUES TESTS ------------------------------
+
+// (-1 * -1) + (-1 * -1) + ... - 20 = 0
+#[test(should_fail_with = "call to assert_max_bit_size")]
+fn test_evaluate_quadratic_expression_limb_overflow() {
+    let one: BN254_Fq = BN254_Fq::one();
+    let v: BN254_Fq = BigNum::from_limbs([20 as u128, 0, 0]);
+
+    let lhs_terms: [[BN254_Fq; 1]; 20] = [[one; 1]; 20];
+    let lhs_flags: [[bool; 1]; 20] = [[true; 1]; 20];
+    let rhs_terms: [[BN254_Fq; 1]; 20] = [[one; 1]; 20];
+    let rhs_flags: [[bool; 1]; 20] = [[true; 1]; 20];
+    let linear_terms: [BN254_Fq; 1] = [v];
+    let linear_flags: [bool; 1] = [true];
+    evaluate_quadratic_expression(
+        lhs_terms,
+        lhs_flags,
+        rhs_terms,
+        rhs_flags,
+        linear_terms,
+        linear_flags,
+    );
+}
+
 // ------------------------------ BASIC TESTS ------------------------------
 
 #[test]
@@ -293,9 +439,46 @@ fn test_derive_from_seed() {
 fn test_validate_derive_from_seed() {
     let seed: [u8; 4] = [1, 2, 3, 4];
     let result_bn: ED25519_Fq = ED25519_Fq::derive_from_seed(seed);
-    assert(result_bn.get_limb(0) == 0x7ade1ed2cfc50de7855f7b290895cf);
-    assert(result_bn.get_limb(1) == 0x084a5fc748bdf0d52b06a5a8538ff6);
-    assert(result_bn.get_limb(2) == 0x0000000000000000000000000044e7);
+    assert(result_bn.get_limb(0) == 0x2469fc2c6b98cc4124308cd04858d9);
+    assert(result_bn.get_limb(1) == 0x54cb58c2bf25863ff8a4b720f59eb4);
+    assert(result_bn.get_limb(2) == 0x000000000000000000000000007243);
+}
+
+// ------------------------------ LIMB ACCESS TESTS ------------------------------
+
+// from_limbs must reject limbs that exceed the valid range.
+#[test(should_fail)]
+fn test_from_limbs_rejects_oversized_top_limb() {
+    // BN254_Fq top limb is 14 bits, 0x10000 = 2^16 exceeds that
+    let _: BN254_Fq = BN254_Fq::from_limbs([0, 0, 0x10000]);
+}
+
+// from_limbs_unsafe accepts limbs that exceed the valid range.
+#[test]
+fn test_from_limbs_unsafe_accepts_oversized_top_limb() {
+    let _: BN254_Fq = BN254_Fq::from_limbs_unsafe([0, 0, 0x10000]);
+}
+
+// set_limb must reject a value that exceeds the valid range for the top limb.
+#[test(should_fail)]
+fn test_set_limb_rejects_oversized_top_limb() {
+    let mut a: BN254_Fq = BN254_Fq::zero();
+    a.set_limb(2, 0x10000);
+}
+
+// set_limb must reject a value that exceeds 120 bits for a non-top limb.
+#[test(should_fail)]
+fn test_set_limb_rejects_oversized_non_top_limb() {
+    let mut a: BN254_Fq = BN254_Fq::zero();
+    a.set_limb(0, TWO_POW_120);
+}
+
+// set_limb_unsafe accepts values that exceed the valid range.
+#[test]
+fn test_set_limb_unsafe_accepts_oversized() {
+    let mut a: BN254_Fq = BN254_Fq::zero();
+    a.set_limb_unsafe(2, 0x10000);
+    assert(a.get_limb(2) == 0x10000);
 }
 
 // ------------------------------ CONVERSION TESTS ------------------------------
@@ -342,6 +525,80 @@ fn test_from_field_3_digits_BLS381() {
         0x0,
     ]);
     assert(result == expected);
+}
+
+// MOD_BITS < 254: validates via validate_in_field(MOD).
+#[test]
+fn test_from_field_mod_bits_lt_254() {
+    let modulus: [u128; 3] = BLS12_377_Fr::modulus().get_limbs();
+    let _neg_one: Field = (modulus[0] as Field)
+        + (modulus[1] as Field) * (TWO_POW_120 as Field)
+        + (modulus[2] as Field) * TWO_POW_240
+        - 1;
+    let neg_one_bls12_377_fr: [u128; 3] = from_field(&BLS12_377_Fr::params(), _neg_one);
+
+    // Safety: test code
+    let true_neg_one_bls12_377_fr = unsafe { BLS12_377_Fr::one().__neg().get_limbs() };
+    assert(true_neg_one_bls12_377_fr == neg_one_bls12_377_fr);
+}
+
+// MOD_BITS > 254: validates via validate_gt(GRUMPKIN, result).
+#[test]
+fn test_from_field_mod_bits_gt_254() {
+    let result: [u128; 4] = from_field(&BLS12_377_Fq::params(), -1 as Field);
+    assert(result[0] == GRUMPKIN_MODULUS[0] - 1);
+    assert(result[1] == GRUMPKIN_MODULUS[1]);
+    assert(result[2] == GRUMPKIN_MODULUS[2]);
+    assert(result[3] == 0);
+}
+
+// MOD_BITS == 254, MOD == GRUMPKIN: all limbs equal, min = GRUMPKIN.
+#[test]
+fn test_from_field_254_eq_grumpkin() {
+    let params: BigNumParams<3, 254> = BigNumParams::new(false, GRUMPKIN_MODULUS, [0 as u128; 3]);
+    let _neg_one: Field = -1;
+    let result: [u128; 3] = from_field(&params, _neg_one);
+    assert(result[0] == GRUMPKIN_MODULUS[0] - 1);
+    assert(result[1] == GRUMPKIN_MODULUS[1]);
+    assert(result[2] == GRUMPKIN_MODULUS[2]);
+}
+
+// MOD_BITS == 254, MOD > GRUMPKIN (BN254_Fq): middle limb decides, min = GRUMPKIN.
+#[test]
+fn test_from_field_254_gt_grumpkin() {
+    let result: [u128; 3] = from_field(&BN254_Fq::params(), -1 as Field);
+    assert(result[0] == GRUMPKIN_MODULUS[0] - 1);
+    assert(result[1] == GRUMPKIN_MODULUS[1]);
+    assert(result[2] == GRUMPKIN_MODULUS[2]);
+}
+
+// MOD_BITS == 254, MOD > GRUMPKIN: top limb decides despite smaller lower limbs, min = GRUMPKIN.
+#[test]
+fn test_from_field_254_gt_grumpkin_1() {
+    let modulus: [u128; 3] =
+        [GRUMPKIN_MODULUS[0] - 1, GRUMPKIN_MODULUS[1] - 1, GRUMPKIN_MODULUS[2] + 1];
+    let params: BigNumParams<3, 254> = BigNumParams::new(false, modulus, [0 as u128; 3]);
+    let result: [u128; 3] = from_field(&params, -1 as Field);
+    assert(result[0] == GRUMPKIN_MODULUS[0] - 1);
+    assert(result[1] == GRUMPKIN_MODULUS[1]);
+    assert(result[2] == GRUMPKIN_MODULUS[2]);
+}
+
+// MOD_BITS == 254, MOD < GRUMPKIN: top limb decides despite larger lower limbs, min = MOD.
+#[test]
+fn test_from_field_254_lt_grumpkin() {
+    let modulus: [u128; 3] =
+        [GRUMPKIN_MODULUS[0] + 1, GRUMPKIN_MODULUS[1] + 1, GRUMPKIN_MODULUS[2] - 1];
+    let params: BigNumParams<3, 254> = BigNumParams::new(false, modulus, [0 as u128; 3]);
+
+    let _neg_one: Field = (modulus[0] as Field)
+        + (modulus[1] as Field) * (TWO_POW_120 as Field)
+        + (modulus[2] as Field) * TWO_POW_240
+        - 1;
+    let result: [u128; 3] = from_field(&params, _neg_one);
+    assert(result[0] == modulus[0] - 1);
+    assert(result[1] == modulus[1]);
+    assert(result[2] == modulus[2])
 }
 
 #[test]
@@ -461,6 +718,67 @@ fn fuzz_to_be_bytes(seed: [u8; 5]) {
     assert(a == b);
 }
 
+// from_be_bytes must reject non-canonical values (>= MOD) via validate_in_field.
+#[test(should_fail)]
+fn test_from_be_bytes_non_canonical() {
+    // Construct bytes for MOD itself (non-canonical zero)
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let modulus_bytes: [u8; 32] = modulus.to_be_bytes_unsafe();
+    let _: BN254_Fq = BN254_Fq::from_be_bytes(modulus_bytes);
+}
+
+// from_le_bytes must reject non-canonical values (>= MOD) via validate_in_field.
+#[test(should_fail)]
+fn test_from_le_bytes_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let modulus_bytes: [u8; 32] = modulus.to_le_bytes_unsafe();
+    let _: BN254_Fq = BN254_Fq::from_le_bytes(modulus_bytes);
+}
+
+// from_be_bytes_unsafe accepts non-canonical values (>= MOD).
+#[test]
+fn test_from_be_bytes_unsafe_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let modulus_bytes: [u8; 32] = modulus.to_be_bytes_unsafe();
+    let _: BN254_Fq = BN254_Fq::from_be_bytes_unsafe(modulus_bytes);
+}
+
+// from_le_bytes_unsafe accepts non-canonical values (>= MOD).
+#[test]
+fn test_from_le_bytes_unsafe_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let modulus_bytes: [u8; 32] = modulus.to_le_bytes_unsafe();
+    let _: BN254_Fq = BN254_Fq::from_le_bytes_unsafe(modulus_bytes);
+}
+
+// to_be_bytes must reject non-canonical values (>= MOD) via validate_in_field.
+#[test(should_fail)]
+fn test_to_be_bytes_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let _: [u8; 32] = modulus.to_be_bytes();
+}
+
+// to_le_bytes must reject non-canonical values (>= MOD) via validate_in_field.
+#[test(should_fail)]
+fn test_to_le_bytes_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let _: [u8; 32] = modulus.to_le_bytes();
+}
+
+// to_be_bytes_unsafe accepts non-canonical values (>= MOD).
+#[test]
+fn test_to_be_bytes_unsafe_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let _: [u8; 32] = modulus.to_be_bytes_unsafe();
+}
+
+// to_le_bytes_unsafe accepts non-canonical values (>= MOD).
+#[test]
+fn test_to_le_bytes_unsafe_non_canonical() {
+    let modulus: BN254_Fq = BN254_Fq::modulus();
+    let _: [u8; 32] = modulus.to_le_bytes_unsafe();
+}
+
 // ------------------------------ COMPARISON TESTS ------------------------------
 
 fn test_eq<let N: u32, BN>()
@@ -491,18 +809,18 @@ where
 {
     let zero: BN = BN::zero();
     assert(zero.is_zero() == true);
-    assert(zero.is_zero_integer() == true);
+    assert(zero.unsafe_is_zero_integer() == true);
 
     let a: BN = BN::derive_from_seed([1, 2, 3, 4]);
     assert(a.is_zero() == false);
-    assert(a.is_zero_integer() == false);
+    assert(a.unsafe_is_zero_integer() == false);
     a.assert_is_not_zero();
-    a.assert_is_not_zero_integer();
+    a.unsafe_assert_is_not_zero_integer();
 
     let modulus: BN = BN::modulus();
     assert(modulus.is_zero() == true);
-    assert(modulus.is_zero_integer() == false);
-    modulus.assert_is_not_zero_integer();
+    assert(modulus.unsafe_is_zero_integer() == false);
+    modulus.unsafe_assert_is_not_zero_integer();
 }
 
 fn test_assert_is_not_equal<let N: u32, BN>()
@@ -537,7 +855,7 @@ where
     let t0 = a.get_limbs();
     let t1 = modulus.get_limbs();
     // Safety: test code
-    let a_plus_modulus: BN = BN::from_limbs(unsafe { __helper_add(&t0, &t1) });
+    let a_plus_modulus: BN = BN::from_limbs_unsafe(unsafe { __helper_add(&t0, &t1) });
     a_plus_modulus.assert_is_not_equal(&b);
 }
 
@@ -553,7 +871,7 @@ where
     let t0 = b.get_limbs();
     let t1 = modulus.get_limbs();
     // Safety: test code
-    let b_plus_modulus = BN::from_limbs(unsafe { __helper_add(&t0, &t1) });
+    let b_plus_modulus = BN::from_limbs_unsafe(unsafe { __helper_add(&t0, &t1) });
     a.assert_is_not_equal(&b_plus_modulus);
 }
 
@@ -570,9 +888,9 @@ where
     let t1 = b.get_limbs();
     let t2 = modulus.get_limbs();
     // Safety: test code
-    let a_plus_modulus: BN = BN::from_limbs(unsafe { __helper_add(&t0, &t2) });
+    let a_plus_modulus: BN = BN::from_limbs_unsafe(unsafe { __helper_add(&t0, &t2) });
     // Safety: test code
-    let b_plus_modulus: BN = BN::from_limbs(unsafe { __helper_add(&t1, &t2) });
+    let b_plus_modulus: BN = BN::from_limbs_unsafe(unsafe { __helper_add(&t1, &t2) });
     a_plus_modulus.assert_is_not_equal(&b_plus_modulus);
 }
 
@@ -645,8 +963,7 @@ fn fuzz_cmp_equal(seed: [u8; 5]) {
     assert(c == false);
 }
 
-// This test verifies the `validate_in_field` docstring note
-fn test_validate_in_field_modulus<let N: u32, BN>()
+fn test_validate_in_field_modulus_fail<let N: u32, BN>()
 where
     BN: BigNum,
 {
@@ -679,14 +996,14 @@ where
     assert(a == c);
 }
 
-// -0 == MOD
+// -0 == 0
 fn test_neg_zero<let N: u32, BN>()
 where
     BN: BigNum,
 {
     let zero: BN = BN::zero();
     let a = -zero;
-    assert(a == BN::modulus());
+    assert(a == zero);
 }
 
 fn test_add<let N: u32, BN>()
@@ -1010,9 +1327,9 @@ fn test_assert_is_not_equal_overloaded_fail_BN() {
     test_assert_is_not_equal_overloaded_fail::<3, BN254_Fq>();
 }
 
-#[test]
-fn test_validate_in_field_modulus_BN() {
-    test_validate_in_field_modulus::<3, BN254_Fq>();
+#[test(should_fail_with = "assert_is_not_zero_integer fail")]
+fn test_validate_in_field_modulus_fail_BN() {
+    test_validate_in_field_modulus_fail::<3, BN254_Fq>();
 }
 
 #[test]
@@ -1102,9 +1419,9 @@ fn test_assert_is_not_equal_overloaded_fail_U256() {
     test_assert_is_not_equal_overloaded_fail::<3, U256>();
 }
 
-#[test]
-fn test_validate_in_field_modulus_U256() {
-    test_validate_in_field_modulus::<3, U256>();
+#[test(should_fail_with = "assert_is_not_zero_integer fail")]
+fn test_validate_in_field_modulus_fail_U256() {
+    test_validate_in_field_modulus_fail::<3, U256>();
 }
 
 #[test]
@@ -1174,9 +1491,9 @@ fn test_assert_is_not_equal_overloaded_fail_BN2048() {
     test_assert_is_not_equal_overloaded_fail::<18, BN2048>();
 }
 
-#[test]
-fn test_validate_in_field_modulus_BN2048() {
-    test_validate_in_field_modulus::<18, BN2048>();
+#[test(should_fail_with = "assert_is_not_zero_integer fail")]
+fn test_validate_in_field_modulus_fail_BN2048() {
+    test_validate_in_field_modulus_fail::<18, BN2048>();
 }
 
 #[test]
@@ -1234,11 +1551,6 @@ fn test_mul_u512() {
 #[test]
 fn test_mul_u768() {
     test_mul::<7, crate::fields::U768::U768>();
-}
-
-#[test]
-fn test_mul_u8192() {
-    test_mul::<69, crate::fields::U8192::U8192>();
 }
 
 #[test]

--- a/src/tests/runtime_bignum_test.nr
+++ b/src/tests/runtime_bignum_test.nr
@@ -79,6 +79,7 @@ comptime fn make_test(_m: Module, N: u32, MOD_BITS: u32, params: Quoted) -> Quot
     let __one = quote { crate::fns::unconstrained_helpers::__one };
     let __shl = quote { crate::fns::unconstrained_helpers::__shl };
     let udiv = quote { crate::fns::constrained_ops::udiv };
+    let udiv_unsafe = quote { crate::fns::constrained_ops::udiv_unsafe };
     let sub = quote { crate::fns::constrained_ops::sub };
     quote {
 
@@ -319,9 +320,9 @@ fn test_is_zero() {
     let b: $RuntimeBigNum<$N, $MOD_BITS> = $RuntimeBigNum::derive_from_seed(params, [1, 2, 3, 4]);
 
     assert(a.is_zero() == true);
-    assert(a.is_zero_integer() == true);
+    assert(a.unsafe_is_zero_integer() == true);
     assert(b.is_zero() == false);
-    assert(b.is_zero_integer() == false);
+    assert(b.unsafe_is_zero_integer() == false);
 
     b.assert_is_not_zero();
 }
@@ -390,11 +391,11 @@ fn test_cmp_fuzz(seed: [u8; 2]){
     one[0] = 1;
     if modulus[0] % 2 == 0 {
         // if modulus is even, half_modulus is modulus / 2
-        half_modulus = $RuntimeBigNum {limbs: $udiv::<$N, $MOD_BITS>(&modulus, &two), params};
+        half_modulus = $RuntimeBigNum {limbs: $udiv_unsafe::<$N, $MOD_BITS>(&modulus, &two), params};
     } else {
         // if modulus is odd, half_modulus is (modulus - 1) / 2
-        let modulus_minus_one = $sub(&params,&modulus, &one);
-        half_modulus = $RuntimeBigNum {limbs: $udiv::<$N, $MOD_BITS>(&modulus_minus_one, &two), params};
+        let modulus_minus_one = $sub(&params, &modulus, &one);
+        half_modulus = $RuntimeBigNum {limbs: $udiv::<$N, $MOD_BITS>(&params, &modulus_minus_one, &two), params};
     }
 
 
@@ -457,25 +458,25 @@ fn test_quadratic_expression() {
 }
 }
 
-#[make_test(3, 254, quote {crate::fields::bn254Fq::BN254_Fq_PARAMS})]
+#[make_test(3, 254, quote { crate::fields::bn254Fq::BN254_Fq_PARAMS })]
 pub mod BNTests {}
 
-#[make_test(3, 256, quote {crate::fields::secp256k1Fq::Secp256k1_Fq_PARAMS})]
+#[make_test(3, 256, quote { crate::fields::secp256k1Fq::Secp256k1_Fq_PARAMS })]
 pub mod Secp256K1FqTests {}
 
-#[make_test(4, 381, quote {crate::fields::bls12_381Fq::BLS12_381_Fq_PARAMS})]
+#[make_test(4, 381, quote { crate::fields::bls12_381Fq::BLS12_381_Fq_PARAMS })]
 pub mod BLS12_381FqTests {}
 
-#[make_test(18, 2048, quote {super::TEST_2048_PARAMS})]
+#[make_test(18, 2048, quote { super::TEST_2048_PARAMS })]
 pub mod Test2048Tests {}
 
-#[make_test(3, 255, quote {crate::fields::bls12_381Fr::BLS12_381_Fr_PARAMS})]
+#[make_test(3, 255, quote { crate::fields::bls12_381Fr::BLS12_381_Fr_PARAMS })]
 pub mod BLS12_381_Fr_ParamsTests {}
 
-#[make_test(4, 377, quote {crate::fields::bls12_377Fq::BLS12_377_Fq_PARAMS})]
+#[make_test(4, 377, quote { crate::fields::bls12_377Fq::BLS12_377_Fq_PARAMS })]
 pub mod BLS12_377_Fq_ParamsTests {}
 
-#[make_test(3, 253, quote {crate::fields::bls12_377Fr::BLS12_377_Fr_PARAMS})]
+#[make_test(3, 253, quote { crate::fields::bls12_377Fr::BLS12_377_Fr_PARAMS })]
 pub mod BLS12_377_Fr_ParamsTests {}
 
 // 98760
@@ -681,4 +682,18 @@ fn test_barrett_reduction_fix() {
     let (_quotient, remainder) =
         unsafe { __barrett_reduction(&to_reduce, &params.redc_param, 1024, &params.modulus) };
     assert((remainder[8] as Field).lt(params.modulus[8] as Field));
+}
+
+// BigNumParams::new must reject a modulus shorter than MOD_BITS (top bit not set).
+#[test(should_fail)]
+fn test_runtime_bignum_params_modulus_too_small() {
+    let modulus: [u128; 3] = [1, 0, 0];
+    let _: BigNumParams<3, 254> = BigNumParams::new(false, modulus, [0 as u128; 3]);
+}
+
+// BigNumParams::new must reject a modulus with limbs exceeding the expected bit width.
+#[test(should_fail)]
+fn test_runtime_bignum_params_modulus_too_large() {
+    let modulus: [u128; 3] = [1, 0, 0x10000];
+    let _: BigNumParams<3, 254> = BigNumParams::new(false, modulus, [0 as u128; 3]);
 }


### PR DESCRIPTION
# Description

This squashes the work done in `noir-bignum-external-audit-fixes` (11 commits on top of v0.10.0) into a single commit, addressing all 11 findings from the external audit.

## Audit findings

### #1 — `evaluate_quadratic_expression` assumption on max `NUM_PRODUCTS` is too permissive

The function is documented to support up to 63 products, enforced by a non-circuit check, on the argument that fewer than 64 products keeps all intermediate values within the range checks performed. Those range checks can in fact fail at a much lower number.

**Fix:** the `assert` condition now estimates the maximal possible limb and verifies it stays in range.

### #2 — `compute_linear_expressions` is incomplete for many small negative values

Intermediate values are stored as limbs designed to be "small" and positive, and `params.double_modulus` is added unconditionally to keep them positive when summing negative values. For very small negative values the `double_modulus` terms can add up to intermediate limbs exceeding 126 bits.

**Fix:** documented the behaviour, referring to the newly added assert in `evaluate_quadratic_expression`.

### #3 — `cmp` is unsound for non-canonical inputs

`cmp` compares the integers from the internal representation of a `BigNum`, which may not match what the user expects. Non-canonical values are reachable either by negating zero (yielding `-MOD` with an honest prover) or by using a malicious witness computation to skip the optional subtraction of `MOD` in an arithmetic operation (yielding `r + MOD`). The first is a completeness issue; the second is a soundness issue.

**Fix:**
- `neg` now returns `0` rather than `MOD` for a zero input
- `validate_in_field` now checks `val < MOD`
- added a safety note on `cmp` usage

### #4 — `assert_is_not_zero_integer` is dangerous

The function is public and part of the `BigNum` trait, but only behaves as expected on canonical input — and no function in the library constrains its return value to be canonical, so it is easy to misuse.

**Fix:** renamed to `unsafe_is_zero_integer` and `unsafe_assert_is_not_zero_integer`.

### #5 — `derive_from_seed` used as a hash function has collisions

Input bytes are packed into fields by treating chunks of up to 31 bytes as a big-endian encoded field with no padding. Without padding, the same field can be encoded with a varying number of leading zeroes, so the function collides on inputs of different size.

**Fix:** pad the seed with its length.

### #6 — `udiv_mod` is unsound for non-canonical inputs

The soundness of `udiv_mod` rests on `validate_gt`, which is not sound for non-canonical inputs (finding #3). A malicious prover can output an unreduced `BigNum` from an arithmetic operation and use it as the divisor, and the constraints pass with invalid quotient and remainder.

**Fix:**
- added `validate_in_field` on both the divisor and the numerator
- added unchecked variants (`udiv_mod_unsafe`, `udiv_unsafe`, `umod_unsafe`) for pre-validated inputs
- added tests for non-canonical numerator and divisor rejection

### #7 — Serialization doesn't enforce canonical representations

For some values two different byte arrays deserialize to the same field element (one encoding `x`, the other `x + MOD`), and the same field element can serialize to two different byte arrays. This is a problem wherever aliasing in the byte encoding is not expected — for example a protocol that hashes a `BigNum` through SHA-256.

**Fix:** added `validate_in_field` on input/output values, plus unsafe variants of these functions.

### #8 — `BigNumParams` doesn't validate the size of the modulus

In a `RuntimeBigNum` the modulus is a witness value chosen by the prover, but the library assumes throughout that the modulus occupies exactly `MOD_BITS`. A prover could choose a modulus using fewer bits — breaking the invariant that limbs encode `x` or `x + MOD` for `x < MOD`, and making `is_zero` and `assert_is_not_equal` unsound — or one using more than `MOD_BITS` via an oversized top limb, or limbs of more than 120 bits carrying borrow bits.

**Fix:**
- added a `validate_in_range` call on the modulus
- added the `top_limb - 2^(TOP_LIMB_BITS - 1) < 2^(TOP_LIMB_BITS - 1)` assertion

### #9 — Incorrect requirement in `BigNum::__div` documentation

The docs state a requirement that `MOD` be prime and `params.has_multiplicative_inverse == true`, but the derive macro implements the non-prime case via `__udiv_mod`.

**Fix:** corrected the docstring.

### #10 — `is_zero_integer` and `assert_is_not_zero_integer` are unsound for generic `T`

Both are generic over `T: Into<Field>`, but the implementation requires range-constrained limbs for soundness; without that, `limb_sum` can overflow to zero when not all limbs are zero. Both are publicly exposed via the `internal` module.

**Fix:** removed the generic parameterization. `validate_in_field` now calls `validate_gt` directly, as the only behavioural difference was the `assert_is_not_zero_integer` check.

### #11 — `from_field` accepts aliases in some configurations

`from_field` branches on `MOD_BITS` for moduli smaller than, larger than, and equal in size to the Grumpkin modulus, but the threshold used is 253, which is not the bit size of the Grumpkin modulus. When `MOD_BITS > 253` the function checks `grumpkin_modulus > result`, which is insufficient when `params.modulus` is smaller than `grumpkin_modulus`.

**Fix:** changed the threshold to 254 and fixed the comparison loop. Added further tests.

## Supporting changes

- **Degenericize `validate_in_range`** to take `[u128; N]` directly, as the `Field` is no longer used anywhere.
- **Add range checks to `from_limbs` / `set_limb`**, along with unsafe variants that skip them. Range constraints are not deduplicated, so this should not cost performance.
- **Use `from_limbs_unsafe` to construct non-canonical test inputs** in the `test_assert_is_not_equal_overloaded_*_fail` helpers, so the new `from_limbs` range check doesn't fire before the `assert_is_not_equal` check under test.

## Breaking changes

- `cmp` now requires canonical form, and `neg` no longer produces non-canonical values.
- `is_zero_integer` / `assert_is_not_zero_integer` are renamed to `unsafe_is_zero_integer` / `unsafe_assert_is_not_zero_integer`, and are no longer generic.
- Serialization and deserialization enforce canonical values; use the new unsafe variants for the previous behaviour.
