### PR TITLE
fix: skip Grumpkin modulus check in `to_field` when `MOD_BITS < 254`

### DIFF
--- a/src/fns/constrained_ops.nr
+++ b/src/fns/constrained_ops.nr
@@ -22,7 +22,16 @@ pub(crate) fn limbs_to_field<let N: u32, let MOD_BITS: u32>(
     limbs: &[u128; N],
 ) -> Field {
     validate_in_range::<N, MOD_BITS>(limbs);
-    if N > 2 {
+    // `validate_in_range` bounds `limbs` by `2^MOD_BITS`, so when `MOD_BITS < 254` the value is
+    // already known to be smaller than the Grumpkin modulus: the latter's top limb is `0x3064`,
+    // hence `GRUMPKIN_MODULUS > 0x3064 * 2^240 > 2^253`. Only `MOD_BITS >= 254` needs the
+    // explicit comparison below.
+    //
+    // The comparison must be *skipped* rather than left in as a redundant check: `validate_gt`
+    // range-constrains the top limb of `GRUMPKIN_MODULUS - limbs` to `MOD_BITS - (N - 1) * 120`
+    // bits, which for e.g. `MOD_BITS = 253, N = 3` is 13 bits — too tight to hold the Grumpkin
+    // modulus' own 14-bit top limb, so every value would fail the range check.
+    if (N > 2) & (MOD_BITS >= 254) {
         // validate that the `BigNum` is less than the Grumpkin modulus
         let mut grumpkin_modulus: [u128; N] = [0; N];
         grumpkin_modulus[0] = GRUMPKIN_MODULUS[0];

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -708,11 +708,11 @@ fn test_to_from_field_2() {
 /// modulus by construction and `to_field` must not attempt (and fail) to compare against it.
 #[test]
 fn test_to_field_mod_bits_below_254() {
-    let one: BLS12_377_Fr = BigNum::one();
+    let one = BLS12_377_Fr::one();
     assert(to_field(one) == 1);
 
     // the largest representable value, `modulus - 1`
-    let max: BLS12_377_Fr = BigNum::modulus() - BigNum::one();
+    let max = BLS12_377_Fr::modulus() - BLS12_377_Fr::one();
     assert(
         to_field(max)
             == 8444461749428370424248824938781546531375899335154063827935233455917409239040,

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -709,23 +709,22 @@ fn test_to_from_field_2() {
 #[test]
 fn test_to_field_mod_bits_below_254() {
     let one = BLS12_377_Fr::one();
-    assert(to_field(one) == 1);
+    assert_eq(to_field(one), 1);
 
     // the largest representable value, `modulus - 1`
+    let BLS12_377_FR_MODULUS_MINUS_ONE: Field =
+        8444461749428370424248824938781546531375899335154063827935233455917409239040;
     let max = BLS12_377_Fr::modulus() - BLS12_377_Fr::one();
-    assert(
-        to_field(max)
-            == 8444461749428370424248824938781546531375899335154063827935233455917409239040,
-    );
+    assert_eq(to_field(max), BLS12_377_FR_MODULUS_MINUS_ONE);
 }
 
 /// Regression test for https://github.com/noir-lang/noir-bignum/issues/266
 #[test]
 fn fuzz_to_from_field_mod_bits_below_254(seed: [u8; 5]) {
-    let a: BLS12_377_Fr = BigNum::derive_from_seed(seed);
+    let a: BLS12_377_Fr = BLS12_377_Fr::derive_from_seed(seed);
     let b: Field = to_field(a);
     let c: BLS12_377_Fr = BLS12_377_Fr::from(b);
-    assert(a == c);
+    assert_eq(a, c);
 }
 
 #[test]

--- a/src/tests/bignum_test.nr
+++ b/src/tests/bignum_test.nr
@@ -702,6 +702,32 @@ fn test_to_from_field_2() {
     assert(a == c);
 }
 
+/// Regression test for https://github.com/noir-lang/noir-bignum/issues/266
+///
+/// `BLS12_377_Fr` has `MOD_BITS = 253` and `N = 3`, so every value is below the Grumpkin
+/// modulus by construction and `to_field` must not attempt (and fail) to compare against it.
+#[test]
+fn test_to_field_mod_bits_below_254() {
+    let one: BLS12_377_Fr = BigNum::one();
+    assert(to_field(one) == 1);
+
+    // the largest representable value, `modulus - 1`
+    let max: BLS12_377_Fr = BigNum::modulus() - BigNum::one();
+    assert(
+        to_field(max)
+            == 8444461749428370424248824938781546531375899335154063827935233455917409239040,
+    );
+}
+
+/// Regression test for https://github.com/noir-lang/noir-bignum/issues/266
+#[test]
+fn fuzz_to_from_field_mod_bits_below_254(seed: [u8; 5]) {
+    let a: BLS12_377_Fr = BigNum::derive_from_seed(seed);
+    let b: Field = to_field(a);
+    let c: BLS12_377_Fr = BLS12_377_Fr::from(b);
+    assert(a == c);
+}
+
 #[test]
 fn fuzz_from_le_bytes(seed: [u8; 5]) {
     let a: BN254_Fq = BN254_Fq::derive_from_seed(seed);


### PR DESCRIPTION
## Description

Resolves #266.

`limbs_to_field` compared every `N > 2` value against the Grumpkin modulus, but `validate_in_range` already bounds values by `2^MOD_BITS`, which is below the Grumpkin modulus whenever `MOD_BITS < 254` (its top limb is `0x3064`, so `GRUMPKIN_MODULUS > 2^253`).

The comparison wasn't just redundant in that case — it was broken: `validate_gt` range-constrains the top limb of `GRUMPKIN_MODULUS - limbs` to `MOD_BITS - (N - 1) * 120` bits, which for e.g. BLS12-377 Fr (`MOD_BITS = 253`, `N = 3`) is 13 bits — too tight to hold the Grumpkin modulus' own 14-bit top limb, so every `to_field` call on such moduli failed.

This PR skips the comparison when `MOD_BITS < 254` and adds regression tests (unit + fuzz round-trip) using `BLS12_377_Fr`.